### PR TITLE
Add support for GraphQL mutations with responses

### DIFF
--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -12,10 +12,10 @@ import Foundation
 
 // MARK: Network
 
-/// Provides an API to create Publishers of GraphQL responses via ApolloClient
+/// Provides an API to create Publishers that execute GraphQL requests and return responses via ApolloClient
 class Network {
     static let shared = Network()
-    let apollo = ApolloClient(url: Secrets.endpoint)
+    private let apollo = ApolloClient(url: Secrets.endpoint)
     
     /// Create a Publisher using a GraphQLQuery
     func publisher<Query: GraphQLQuery>(for query: Query) -> OperationPublisher<Query.Data> {

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -45,6 +45,8 @@ private protocol Operation {
     typealias Handler = (Result<GraphQLResult<Data>, Error>) -> Void
     
     func execute(client: ApolloClient, resultHandler: @escaping Handler)
+    
+    func toAny() -> AnyOperation<Data>
 }
 
 private struct QueryOperation<Q: GraphQLQuery>: Operation {

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -7,7 +7,6 @@
 //
 
 import AppDevAnalytics
-import Combine
 import LinkPresentation
 import SDWebImageSwiftUI
 import SwiftUI

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -7,6 +7,7 @@
 //
 
 import AppDevAnalytics
+import Combine
 import LinkPresentation
 import SDWebImageSwiftUI
 import SwiftUI
@@ -144,9 +145,3 @@ struct BrowserView: View {
         }
     }
 }
-
-//struct BrowserView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        BrowserView()
-//    }
-//}

--- a/Volume/Views/MainView/BookmarksList.swift
+++ b/Volume/Views/MainView/BookmarksList.swift
@@ -24,7 +24,7 @@ struct BookmarksList: View {
 
         cancellableQuery = userData.savedArticleIDs.publisher
             .map(GetArticleByIdQuery.init)
-            .flatMap(Network.shared.apollo.publisher)
+            .flatMap(Network.shared.publisher)
             .collect()
             .sink { completion in
                 networkState.handleCompletion(screen: .bookmarksList, completion)

--- a/Volume/Views/MainView/BookmarksList.swift
+++ b/Volume/Views/MainView/BookmarksList.swift
@@ -24,7 +24,7 @@ struct BookmarksList: View {
 
         cancellableQuery = userData.savedArticleIDs.publisher
             .map(GetArticleByIdQuery.init)
-            .flatMap(Network.shared.apollo.fetch)
+            .flatMap(Network.shared.apollo.publisher)
             .collect()
             .sink { completion in
                 networkState.handleCompletion(screen: .bookmarksList, completion)

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -20,19 +20,19 @@ struct HomeList: View {
     private func fetch(_ done: @escaping () -> Void = { }) {
         guard state.isLoading else { return }
 
-        cancellableQuery = Network.shared.apollo.fetch(query: GetAllPublicationIDsQuery())
+        cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationIDsQuery())
             .map { $0.publications.map(\.id) }
             .flatMap { publicationIDs -> ResultsPublisher in
-                let trendingQuery = Network.shared.apollo.fetch(query: GetTrendingArticlesQuery(limit: 7))
+                let trendingQuery = Network.shared.apollo.publisher(for: GetTrendingArticlesQuery(limit: 7))
                     .map { $0.articles.map(\.fragments.articleFields) }
 
-                let followedQuery = Network.shared.apollo.fetch(query: GetArticlesByPublicationIDsQuery(ids: userData.followedPublicationIDs))
+                let followedQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIDsQuery(ids: userData.followedPublicationIDs))
                     .map { $0.articles.map(\.fragments.articleFields) }
                     .collect()
 
                 let morePublicationIDs = publicationIDs.filter { !userData.followedPublicationIDs.contains($0) }
 
-                let otherQuery = Network.shared.apollo.fetch(query: GetArticlesByPublicationIDsQuery(ids: morePublicationIDs))
+                let otherQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIDsQuery(ids: morePublicationIDs))
                     .map { $0.articles.map(\.fragments.articleFields) }
                 
                 return Publishers.Zip3(trendingQuery, followedQuery, otherQuery)
@@ -63,7 +63,7 @@ struct HomeList: View {
     }
 
     private func fetchArticleBy(id: String) {
-        cancellableQuery = Network.shared.apollo.fetch(query: GetArticleByIdQuery(id: id))
+        cancellableQuery = Network.shared.apollo.publisher(for: GetArticleByIdQuery(id: id))
             .sink { completion in
                 if case let .failure(error) = completion {
                     print(error.localizedDescription)
@@ -181,9 +181,9 @@ extension HomeList {
     )
     typealias ResultsPublisher =
         Publishers.Zip3<
-            Publishers.Map<GraphQLPublisher<GetTrendingArticlesQuery>,[ArticleFields]>,
-            Publishers.Collect<Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery>, [ArticleFields]>>,
-            Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery>, [ArticleFields]>
+            Publishers.Map<GraphQLPublisher<GetTrendingArticlesQuery.Data>,[ArticleFields]>,
+            Publishers.Collect<Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>>,
+            Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>
         >
 }
 

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -20,19 +20,19 @@ struct HomeList: View {
     private func fetch(_ done: @escaping () -> Void = { }) {
         guard state.isLoading else { return }
 
-        cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationIDsQuery())
+        cancellableQuery = Network.shared.publisher(for: GetAllPublicationIDsQuery())
             .map { $0.publications.map(\.id) }
             .flatMap { publicationIDs -> ResultsPublisher in
-                let trendingQuery = Network.shared.apollo.publisher(for: GetTrendingArticlesQuery(limit: 7))
+                let trendingQuery = Network.shared.publisher(for: GetTrendingArticlesQuery(limit: 7))
                     .map { $0.articles.map(\.fragments.articleFields) }
 
-                let followedQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIDsQuery(ids: userData.followedPublicationIDs))
+                let followedQuery = Network.shared.publisher(for: GetArticlesByPublicationIDsQuery(ids: userData.followedPublicationIDs))
                     .map { $0.articles.map(\.fragments.articleFields) }
                     .collect()
 
                 let morePublicationIDs = publicationIDs.filter { !userData.followedPublicationIDs.contains($0) }
 
-                let otherQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIDsQuery(ids: morePublicationIDs))
+                let otherQuery = Network.shared.publisher(for: GetArticlesByPublicationIDsQuery(ids: morePublicationIDs))
                     .map { $0.articles.map(\.fragments.articleFields) }
                 
                 return Publishers.Zip3(trendingQuery, followedQuery, otherQuery)
@@ -63,7 +63,7 @@ struct HomeList: View {
     }
 
     private func fetchArticleBy(id: String) {
-        cancellableQuery = Network.shared.apollo.publisher(for: GetArticleByIdQuery(id: id))
+        cancellableQuery = Network.shared.publisher(for: GetArticleByIdQuery(id: id))
             .sink { completion in
                 if case let .failure(error) = completion {
                     print(error.localizedDescription)
@@ -181,9 +181,9 @@ extension HomeList {
     )
     typealias ResultsPublisher =
         Publishers.Zip3<
-            Publishers.Map<GraphQLOperationPublisher<GetTrendingArticlesQuery.Data>,[ArticleFields]>,
-            Publishers.Collect<Publishers.Map<GraphQLOperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>>,
-            Publishers.Map<GraphQLOperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>
+            Publishers.Map<OperationPublisher<GetTrendingArticlesQuery.Data>,[ArticleFields]>,
+            Publishers.Collect<Publishers.Map<OperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>>,
+            Publishers.Map<OperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>
         >
 }
 

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -181,9 +181,9 @@ extension HomeList {
     )
     typealias ResultsPublisher =
         Publishers.Zip3<
-            Publishers.Map<GraphQLPublisher<GetTrendingArticlesQuery.Data>,[ArticleFields]>,
-            Publishers.Collect<Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>>,
-            Publishers.Map<GraphQLPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>
+            Publishers.Map<GraphQLOperationPublisher<GetTrendingArticlesQuery.Data>,[ArticleFields]>,
+            Publishers.Collect<Publishers.Map<GraphQLOperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>>,
+            Publishers.Map<GraphQLOperationPublisher<GetArticlesByPublicationIDsQuery.Data>, [ArticleFields]>
         >
 }
 

--- a/Volume/Views/MainView/PublicationList.swift
+++ b/Volume/Views/MainView/PublicationList.swift
@@ -24,7 +24,7 @@ struct PublicationList: View {
             state = .results((followedPublications, morePublications))
         }
 
-        cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationsQuery())
+        cancellableQuery = Network.shared.publisher(for: GetAllPublicationsQuery())
             .map { data in data.publications.compactMap { $0 } }
             .sink(receiveCompletion: { completion in
                 networkState.handleCompletion(screen: .publicationList, completion)

--- a/Volume/Views/MainView/PublicationList.swift
+++ b/Volume/Views/MainView/PublicationList.swift
@@ -24,7 +24,7 @@ struct PublicationList: View {
             state = .results((followedPublications, morePublications))
         }
 
-        cancellableQuery = Network.shared.apollo.fetch(query: GetAllPublicationsQuery())
+        cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationsQuery())
             .map { data in data.publications.compactMap { $0 } }
             .sink(receiveCompletion: { completion in
                 networkState.handleCompletion(screen: .publicationList, completion)

--- a/Volume/Views/Onboarding/FollowView.swift
+++ b/Volume/Views/Onboarding/FollowView.swift
@@ -17,7 +17,7 @@ extension OnboardingView {
         @State private var state: FollowViewState = .loading
 
         private func fetch() {
-            cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationsQuery())
+            cancellableQuery = Network.shared.publisher(for: GetAllPublicationsQuery())
                 .map { data in data.publications.compactMap { $0.fragments.publicationFields } }
                 .sink(receiveCompletion: { completion in
                     if case let .failure(error) = completion {

--- a/Volume/Views/Onboarding/FollowView.swift
+++ b/Volume/Views/Onboarding/FollowView.swift
@@ -17,7 +17,7 @@ extension OnboardingView {
         @State private var state: FollowViewState = .loading
 
         private func fetch() {
-            cancellableQuery = Network.shared.apollo.fetch(query: GetAllPublicationsQuery())
+            cancellableQuery = Network.shared.apollo.publisher(for: GetAllPublicationsQuery())
                 .map { data in data.publications.compactMap { $0.fragments.publicationFields } }
                 .sink(receiveCompletion: { completion in
                     if case let .failure(error) = completion {

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -21,7 +21,7 @@ struct PublicationDetail: View {
     let publication: Publication
 
     private func fetch() {
-        cancellableQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIdQuery(id: publication.id))
+        cancellableQuery = Network.shared.publisher(for: GetArticlesByPublicationIdQuery(id: publication.id))
             .map(\.articles)
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -21,7 +21,7 @@ struct PublicationDetail: View {
     let publication: Publication
 
     private func fetch() {
-        cancellableQuery = Network.shared.apollo.fetch(query: GetArticlesByPublicationIdQuery(id: publication.id))
+        cancellableQuery = Network.shared.apollo.publisher(for: GetArticlesByPublicationIdQuery(id: publication.id))
             .map(\.articles)
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {


### PR DESCRIPTION
## Overview
Redesigned API in `Network.swift` to support GraphQL mutations with Apollo, refactored & added comments. 

## Changes Made
### Redesigned Networking API 

#### Justification
1. Currently, the only mutation in Volume is `IncrementShoutoutsMutation`, which disregards any response from the server. 
2. A `Publisher` is a class provided by `Combine` that we use to declaratively transform streams of data received through GraphQL requests, as demonstrated in [`HomeList.swift`](https://github.com/cuappdev/volume-ios/blob/master/Volume/Views/MainView/HomeList.swift).  

For these two reasons, the API in `Network` only supports creating `Publisher`s for queries (`Apollo.GraphQLQuery`) and not mutations (`Apollo.GraphQLMutation`). **However,** Volume backend is releasing new mutation endpoints that provide useful response data, so we need to add `Publisher`s of mutations to the `Network` API. 

#### Solution
The naïve solution is to duplicate the `GraphQLPublisher` and `GraphQLSubscription` classes and replace every occurrence of `GraphQLQuery` with `GraphQLMutation`. However, since 90% of that code would be repeated, we (@danielVebman and I) chose to find a way to polymorphically inject both queries and mutations into the existing classes.  

Anyone's next instinct would be to change the generic constraint for `GraphQLPublisher` from `GraphQLQuery` to `GraphQLOperation` (the parent protocol of `GraphQLQuery` and `GraphQLOperation`), then cast a value of type `GraphQLOperation` to type `GraphQLQuery` or `GraphQLMutation`. This fails, since `GraphQLOperation` has an `associatedType`.  

The resulting solution takes advantage of "[type erasure](https://www.swiftbysundell.com/articles/different-flavors-of-type-erasure-in-swift/)" that abstracts all unique aspects of a class into its basest properties, allowing uniformly calling the base properties of any value of that erased type. **This eliminates the need for type casting**. In our case, we create structs `QueryOperation` and `MutationOperation` that respectively wrap a query and mutation as values stored in an `execute` closure, which is then used to create a value of type `AnyOperation`, whose sole job is to provide `execute` to `GraphQLOperationSubscription`.  

Finally, we added a method `publisher(for mutation:)` in `ApolloClient` to link it all together. 

### Refactor
- renamed `GraphQLSubscription` to `GraphQLOperationSubscription` since `Apollo. GraphQLSubscription` already exists
- renamed `GraphQLPublisher` to `GraphQLOperationPublisher` for consistency
- renamed `query` in above two classes to `operation` for consistency
- renamed `ApolloClient.fetch(query:)` to `publisher(for query:)`, since the function returns a `Publisher` and does not actually fetch the query
- rearranged file contents to better fit into sections

## Test Coverage
- ensured that queries still work
- ensured that `IncrementShoutoutsMutation` still works
- ‼️ cannot test a mutation with valid response data until updated `schema.json`, `API.swift`, and `*.graphql` have been added

## Next Steps
- update `schema.json` & add new queries & mutations
- implement faster `GetArticlesByPublicationID` query

