### PR TITLE
Add createUser mutation

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -17,15 +17,12 @@
 		06379C74256725C000FC185A /* Begum-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 06379C73256725C000FC185A /* Begum-Regular.ttf */; };
 		06379C792567297400FC185A /* Begum-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 06379C782567297400FC185A /* Begum-Bold.ttf */; };
 		063EED25257BF8A7002136EE /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063EED24257BF8A7002136EE /* Network.swift */; };
-		063EED4A257BFDA9002136EE /* PublicationsQueries.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 063EED49257BFDA9002136EE /* PublicationsQueries.graphql */; };
 		06491F7325787E870045F27D /* TrackableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06491F7225787E870045F27D /* TrackableScrollView.swift */; };
 		06662888257F204E006FEBCF /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06662887257F204E006FEBCF /* Secrets.swift */; };
 		0685AA9E259EA84900DD55C4 /* BrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0685AA9D259EA84900DD55C4 /* BrowserView.swift */; };
 		0685AAA1259EBA3800DD55C4 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0685AAA0259EBA3800DD55C4 /* WebView.swift */; };
-		0685AAA4259EC2AF00DD55C4 /* ArticlesMutations.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 0685AAA3259EC2AF00DD55C4 /* ArticlesMutations.graphql */; };
 		06A8E2532575429200C28C68 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A8E2522575429200C28C68 /* MainView.swift */; };
 		06B23228258EDDA9006D9A53 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B23227258EDDA9006D9A53 /* SkeletonView.swift */; };
-		06B80CFC257D9E9700F3BF9B /* ArticlesQueries.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06B80CFB257D9E9700F3BF9B /* ArticlesQueries.graphql */; };
 		06B80D13257DC18600F3BF9B /* WebImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B80D12257DC18600F3BF9B /* WebImage+Extension.swift */; };
 		06DBC684257DE35F00B6A453 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBC683257DE35F00B6A453 /* UserData.swift */; };
 		06EC2D24259CED0500FE0A71 /* PublicationDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */; };
@@ -98,6 +95,7 @@
 		06DBC683257DE35F00B6A453 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationDetailHeader.swift; sourceTree = "<group>"; };
 		3334F49F2705269800CF0987 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		33AE4CEC27403F670001BA5B /* UserMutations.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserMutations.graphql; sourceTree = "<group>"; };
 		73CCD70394C4621A0C4211D4 /* Pods-Volume.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.release.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.release.xcconfig"; sourceTree = "<group>"; };
 		7E23DFD1254A05EF0001C3A3 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		7E369DF525EEA41300FC0419 /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -191,6 +189,7 @@
 				063EED49257BFDA9002136EE /* PublicationsQueries.graphql */,
 				06B80CFB257D9E9700F3BF9B /* ArticlesQueries.graphql */,
 				0685AAA3259EC2AF00DD55C4 /* ArticlesMutations.graphql */,
+				33AE4CEC27403F670001BA5B /* UserMutations.graphql */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -443,11 +442,8 @@
 				7ED7C343252D117B0078B1BD /* LaunchScreen.storyboard in Resources */,
 				7E369E1725EED97500FC0419 /* Secrets.plist in Resources */,
 				7ED7C340252D117B0078B1BD /* Preview Assets.xcassets in Resources */,
-				063EED4A257BFDA9002136EE /* PublicationsQueries.graphql in Resources */,
-				06B80CFC257D9E9700F3BF9B /* ArticlesQueries.graphql in Resources */,
 				95F1DC8A2608F4DD000B3D91 /* GoogleService-Info.plist in Resources */,
 				95F1DC8D2608F4F9000B3D91 /* schema.json in Resources */,
-				0685AAA4259EC2AF00DD55C4 /* ArticlesMutations.graphql in Resources */,
 				7ED7C33D252D117B0078B1BD /* Assets.xcassets in Resources */,
 				7E91E13626462E7D0059F041 /* Lato-Bold.ttf in Resources */,
 				990081EF25E5C31600BF8362 /* Events.md in Resources */,

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -145,14 +145,14 @@ private class OperationSubscription<Data, S: Subscriber>: Subscription
 class NetworkState: ObservableObject {
     @Published var networkScreenFailed: [Screen : Bool] = [:]
 
-    public enum Screen: CaseIterable {
+    public enum Screen: String, CaseIterable {
         case homeList, publicationList, bookmarksList
     }
 
     func handleCompletion(screen: Screen, _ completion: Subscribers.Completion<WrappedGraphQLError>) {
         if case let .failure(error) = completion {
             networkScreenFailed[screen] = true
-            print(error.localizedDescription)
+            print("Error on \(screen.rawValue): \(error)")
         } else {
             networkScreenFailed[screen] = false
         }

--- a/Volume/Networking/UserMutations.graphql
+++ b/Volume/Networking/UserMutations.graphql
@@ -1,0 +1,5 @@
+mutation CreateUser($deviceToken: String!, $followedPublicationIDs: [String!]!) {
+    user:createUser(deviceType: "IOS", deviceToken: $deviceToken, followedPublications: $followedPublicationIDs) {
+        uuid
+    }
+}

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 Cornell AppDev. All rights reserved.
 //
 
+import SwiftUI
 import UIKit
-import UserNotifications
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let deviceTokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("UIApplicationDelegate didRegisterForRemoteNotifications with deviceToken: \(deviceTokenString)")
-        // send device token to backend
+        UserData.shared.set(deviceToken: deviceTokenString)
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/Volume/Supporting/Main.swift
+++ b/Volume/Supporting/Main.swift
@@ -38,25 +38,18 @@ struct Main: App {
     private func registerForPushNotifications() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             if settings.authorizationStatus == .notDetermined {
-                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
-                    if granted {
-                        DispatchQueue.main.async {
-                            UIApplication.shared.registerForRemoteNotifications()
-                        }
-                    }
-                }
-            } else if settings.authorizationStatus == .authorized {
-                DispatchQueue.main.async {
-                    UIApplication.shared.registerForRemoteNotifications()
-                }
+                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
             }
+        }
+        DispatchQueue.main.async {
+            UIApplication.shared.registerForRemoteNotifications()
         }
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(UserData())
+                .environmentObject(UserData.shared)
                 .environmentObject(NetworkState())
         }
     }

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -80,6 +80,7 @@ class UserData: ObservableObject {
                         print("An error occurred in creating user: \(error)")
                     }
                 } receiveValue: { uuid in
+                    // cache this UUID to use later when mutating user-specific info
                     print("User created on backend with UUID: \(uuid)")
                     UserDefaults.standard.setValue(uuid, forKey: self.userUUIDKey)
                 }

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -91,6 +91,7 @@ struct OnboardingView: View {
                 case .follow:
                     Button(action: {
                         AppDevAnalytics.log(VolumeEvent.completeOnboarding.toEvent(.general))
+                        userData.createUser()
                         withAnimation(.spring()) {
                             isFirstLaunch = false
                         }


### PR DESCRIPTION
## Overview
Implemented `createUser` mutation and relevant functions

## Changes Made
- add `UserMutations.graphql`
- improve error messages in `NetworkState`
- add `UserDefaults` keys to `UserData` for device tokens and user uuid
- add singleton `UserData.shared` to allow access from `AppDelegate`
- register for remote notifications regardless of whether push notifications are granted
  - reasoning: the device token is required to create a user on backend and can only be obtained by registering for remote notification
- add `createUser` function in `UserData` to be called at end of onboarding flow

## Test Coverage
- created user on dev server
- ensured that newly created user UUID is printed on console upon completion

## Next Steps (delete if not applicable)
- add `followPublication` and `unfollowPublication` mutations