### PR TITLE
Implement follow & unfollow mutations

### DIFF
--- a/Volume/Networking/UserMutations.graphql
+++ b/Volume/Networking/UserMutations.graphql
@@ -3,3 +3,19 @@ mutation CreateUser($deviceToken: String!, $followedPublicationIDs: [String!]!) 
         uuid
     }
 }
+
+mutation FollowPublication($publicationID:String!, $uuid:String!) {
+    user: followPublication(pubID:$publicationID, uuid:$uuid) {
+        followedPublications {
+            id
+        }
+    }
+}
+
+mutation UnfollowPublication($publicationID:String!, $uuid:String!) {
+    user: unfollowPublication(pubID:$publicationID, uuid:$uuid) {
+        followedPublications {
+            id
+        }
+    }
+}

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -121,7 +121,14 @@ class UserData: ObservableObject {
 
     func set(publication: Publication, isFollowed: Bool) {
         guard let uuid = UserDefaults.standard.string(forKey: userUUIDKey) else {
-            print("Error: failed to set follow status because user UUID not set")
+            // User has not finished onboarding
+            if isFollowed {
+                if !followedPublicationIDs.contains(publication.id) {
+                    followedPublicationIDs.insert(publication.id, at: 0)
+                }
+            } else {
+                followedPublicationIDs.removeAll(where: { $0 == publication.id })
+            }
             return
         }
         


### PR DESCRIPTION
## Overview
Implemented follow and unfollow mutations

## Changes Made
- Added GraphQL mutations
  - Contain `followedPublications` field for debugging
  - Response is a `User` type (due to backend schema)
- Added error message for null UUID
- Update cache only after follow/unfollow operation successfully return

## Test Coverage
- Verified `followedPublicationIDs` (both cached and from network response) changes accordingly using prints before & after mutation 
