### PR TITLE
Add support for SVGs handled through SDWebImageSwiftUI

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,7 @@ target 'Volume' do
   pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
   pod 'Apollo'
   pod 'SDWebImageSwiftUI'
+  pod 'SDWebImageSVGCoder'
   pod 'SwiftUIRefresh'
   pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/analytics-ios.git', :commit => '5d459c0475'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -74,6 +74,8 @@ PODS:
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
   - SDWebImage/Core (5.11.1)
+  - SDWebImageSVGCoder (1.6.1):
+    - SDWebImage/Core (~> 5.6)
   - SDWebImageSwiftUI (2.0.2):
     - SDWebImage (~> 5.10)
   - SwiftUIRefresh (0.0.3):
@@ -83,6 +85,7 @@ DEPENDENCIES:
   - Apollo
   - AppDevAnalytics (from `https://github.com/cuappdev/analytics-ios.git`, commit `5d459c0475`)
   - AppDevAnnouncements (from `https://github.com/cuappdev/appdev-announcements.git`)
+  - SDWebImageSVGCoder
   - SDWebImageSwiftUI
   - SwiftUIRefresh
 
@@ -101,6 +104,7 @@ SPEC REPOS:
     - nanopb
     - PromisesObjC
     - SDWebImage
+    - SDWebImageSVGCoder
     - SDWebImageSwiftUI
     - SwiftUIRefresh
 
@@ -135,9 +139,10 @@ SPEC CHECKSUMS:
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
   SDWebImageSwiftUI: 8a3923c95108312b03a599ec1498754af55a6819
   SwiftUIRefresh: ca6ae2718d25aad5dd68bbf5d2ae36ef6ade98bf
 
-PODFILE CHECKSUM: e49691507a0045de8b32e1e78401024da3cae7b6
+PODFILE CHECKSUM: e4a4d1e46ade3c4fdd42cda7055692b0f7bc4a65
 
 COCOAPODS: 1.11.2

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import AppDevAnalytics
+import SDWebImageSVGCoder
 import SwiftUI
 import UIKit
 
@@ -15,6 +16,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let notificationIntervalKey = "notificationIntervalKey"
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        // Add SVG Support
+        SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
+
         if let userInfo = launchOptions?[.remoteNotification] as? [AnyHashable: Any] {
             // App was launched by tapping notification
             Notifications.shared.handlePushNotification(userInfo: userInfo)

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -136,10 +136,10 @@ struct HomeList: View {
                             Text("Your\nWeekly\nDebrief")
                                 .font(.begumRegular(size: 18))
                                 .foregroundColor(.volume.orange)
-                                .padding([.leading])
+                                .padding(.leading)
                             Spacer()
                             Image("right-arrow")
-                                .padding([.trailing])
+                                .padding(.trailing)
                         }
                     }
                 }


### PR DESCRIPTION
## Overview

Problem: URLs that linked to images in SVG format were not display.
Solution: Add support for SVGs handled through SDWebImageSwiftUI


## Test Coverage

- Tested on iPhone XR


## Screenshots (delete if not applicable)

<details>

  <summary>Before</summary>

  ![Image from iOS](https://user-images.githubusercontent.com/57964367/153738509-7e93f890-b77b-4d63-b3de-63653cf4df3f.png)
  

</details>


<details>

  <summary>After</summary>

  ![IMG_3091](https://user-images.githubusercontent.com/57964367/153738524-578c742d-5db2-4491-83a9-b81f67bb9710.PNG)
  

</details>
