### PR TITLE
Fix publication page articles bug

### DIFF
--- a/Volume.xcodeproj/xcshareddata/xcschemes/Volume.xcscheme
+++ b/Volume.xcodeproj/xcshareddata/xcschemes/Volume.xcscheme
@@ -53,6 +53,10 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-noFIRAnalyticsDebugEnabled"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Volume/Models/Publication.swift
+++ b/Volume/Models/Publication.swift
@@ -13,6 +13,7 @@ struct Publication: Hashable, Identifiable {
     let name: String
     let numArticles: Int
     let id: String
+    let slug: String
     let profileImageUrl: URL?
     let backgroundImageUrl: URL?
     let recent: String?
@@ -30,6 +31,7 @@ struct Publication: Hashable, Identifiable {
         name = publication.name
         numArticles = Int(publication.numArticles)
         id = publication.id
+        slug = publication.slug
         profileImageUrl = URL(string: publication.profileImageUrl)
         backgroundImageUrl = URL(string: publication.backgroundImageUrl)
         recent = publication.mostRecentArticle?.title

--- a/Volume/Networking/PublicationsQueries.graphql
+++ b/Volume/Networking/PublicationsQueries.graphql
@@ -10,8 +10,15 @@ query GetAllPublicationIDs {
     }
 }
 
+query GetPublicationBySlug($slug: String!) {
+  publication: getPublicationBySlug(slug: $slug) {
+    ...publicationFields
+  }
+}
+
 fragment publicationFields on Publication {
   id
+  slug
   bio
   name
   shoutouts

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("UIApplicationDelegate didRegisterForRemoteNotifications with error: \(error.localizedDescription)")
+        print("Error: UIApplicationDelegate didFailToRegisterForRemoteNotificationsWithError: \(error.localizedDescription)")
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -29,7 +29,7 @@ class Notifications: NSObject, ObservableObject {
                         let event = VolumeEvent.enableNotification.toEvent(.notification, value: "", navigationSource: .unspecified)
                         AppDevAnalytics.log(event)
                     } else if let error = error {
-                        print("Error requesting push notification permissions: \(error)")
+                        print("Error: failed to obtain push notification permissions: \(error.localizedDescription)")
                     }
                 }
             }

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -62,7 +62,7 @@ class UserData: ObservableObject {
             if let encoded = try? JSONEncoder().encode(newValue) {
                 UserDefaults.standard.set(encoded, forKey: weeklyDebriefKey)
             } else {
-                print("Error: failed to encode WeeklyDebrief object and UserData.weeklyDebrief property not set.")
+                print("Error: failed to encode WeeklyDebrief object")
             }
         }
     }
@@ -139,7 +139,7 @@ class UserData: ObservableObject {
             cancellables[.bookmark(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid))
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { _ in
                     if !self.savedArticleIDs.contains(article.id) {
@@ -173,7 +173,7 @@ class UserData: ObservableObject {
             cancellables[.follow(publication)] = Network.shared.publisher(for: mutation)
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: FollowPublicationMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { value in
                     if !self.followedPublicationIDs.contains(publication.id) {
@@ -188,7 +188,7 @@ class UserData: ObservableObject {
             cancellables[.unfollow(publication)] = Network.shared.publisher(for: UnfollowPublicationMutation(publicationID: publication.id, uuid: uuid))
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: UnfollowPublicationMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { _ in
                     self.followedPublicationIDs.removeAll(where: { $0 == publication.id })

--- a/Volume/View Models/ArticleInfo.swift
+++ b/Volume/View Models/ArticleInfo.swift
@@ -25,11 +25,11 @@ struct ArticleInfo: View {
                 }
 
                 Text(article.title)
-                    .multilineTextAlignment(.leading)
                     .font(largeFont ? .latoBold(size: 24) : .latoBold(size: 16))
                     .lineLimit(3)
                     .padding(.top, 0.5)
                     .blur(radius: article.isNsfw ? 3 : 0)
+                    .multilineTextAlignment(.leading)
                 
                 Spacer()
                 HStack {

--- a/Volume/View Models/MorePublicationRow.swift
+++ b/Volume/View Models/MorePublicationRow.swift
@@ -55,6 +55,7 @@ struct MorePublicationRow: View {
                     .padding(.top, 2)
                 }
             }
+            .multilineTextAlignment(.leading)
 
             Spacer()
 

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -176,7 +176,7 @@ struct BrowserView: View {
         cancellableShoutoutMutation = Network.shared.publisher(for: IncrementShoutoutsMutation(id: article.id, uuid: uuid))
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: IncrementShoutoutsMutation failed on BrowserView: \(error.localizedDescription)")
                 }
             }, receiveValue: { _ in })
     }
@@ -186,7 +186,7 @@ struct BrowserView: View {
         cancellableArticleQuery = Network.shared.publisher(for: GetArticleByIdQuery(id: id))
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: GetArticleByIdQuery failed on BrowserView: \(error.localizedDescription)")
                 }
             } receiveValue: { article in
                 if let fields = article.article?.fragments.articleFields {
@@ -201,7 +201,7 @@ struct BrowserView: View {
         cancellableReadMutation = Network.shared.publisher(for: ReadArticleMutation(id: id, uuid: uuid))
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: ReadArticleMutation failed on BrowserView: \(error.localizedDescription)")
                 }
             } receiveValue: { _ in }
     }

--- a/Volume/Views/DebriefArticleView.swift
+++ b/Volume/Views/DebriefArticleView.swift
@@ -56,7 +56,6 @@ struct DebriefArticleView: View {
         Button {
             incrementShoutouts(for: article)
         } label: {
-            let _ = print("the shoutouts is \(max(article.shoutouts, userData.shoutoutsCache[article.id, default: 0]))")
             Image("shout-out")
                 .resizable()
                 .foregroundColor(max(article.shoutouts, userData.shoutoutsCache[article.id, default: 0]) > 0 ? Color.white : Color.volume.orange)
@@ -130,7 +129,7 @@ struct DebriefArticleView: View {
         cancellableShoutoutMutation = Network.shared.publisher(for: IncrementShoutoutsMutation(id: article.id, uuid: uuid))
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: IncrementShoutoutsMutation failed on DebriefArticleView: \(error.localizedDescription)")
                 }
             }, receiveValue: { _ in })
     }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -85,7 +85,7 @@ struct HomeList: View {
             .map(\.user.weeklyDebrief)
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: GetWeeklyDebriefQuery failed on HomeList: \(error.localizedDescription)")
                 }
             } receiveValue: { weeklyDebrief in
                 userData.weeklyDebrief = WeeklyDebrief(from: weeklyDebrief)
@@ -125,7 +125,6 @@ struct HomeList: View {
             case .reloading, .results:
                 Button {
                     isWeeklyDebriefOpen = true
-                    let _ = print("opening ")
                 } label: {
                     ZStack(alignment: .leading) {
                         Image("weekly-debrief-curves")

--- a/Volume/Views/Onboarding/FollowView.swift
+++ b/Volume/Views/Onboarding/FollowView.swift
@@ -21,7 +21,7 @@ extension OnboardingView {
                 .map { data in data.publications.compactMap { $0.fragments.publicationFields } }
                 .sink(receiveCompletion: { completion in
                     if case let .failure(error) = completion {
-                        print(error.localizedDescription)
+                        print("Error: GetAllPublicationsQuery failed on FollowView: \(error.localizedDescription)")
                     }
                 }, receiveValue: { value in
                     state = .results([Publication](value))

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -146,7 +146,7 @@ struct OnboardingView: View {
             .map { $0.user.uuid }
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print("An error occurred while creating user: \(error)")
+                    print("Error: failed to create user: \(error.localizedDescription)")
                 }
             } receiveValue: { uuid in
                 userData.uuid = uuid

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -26,7 +26,7 @@ struct PublicationDetail: View {
             .map { $0.publication.map({ $0.fragments.publicationFields.id })! }
             .sink {
                 if case let .failure(error) = $0 {
-                    print("GetPublicationBySlugQuery failed: \(error)")
+                    print("Error: GetPublicationBySlugQuery failed on PublicationDetail: \(error.localizedDescription)")
                 }
             } receiveValue: {
                 fetchArticles(by: $0)

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -25,7 +25,7 @@ struct PublicationDetail: View {
             .map(\.articles)
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: GetArticlesByPublicationIdQuery failed on PublicationDetail: \(error.localizedDescription)")
                 }
             }, receiveValue: { value in
                 withAnimation(.linear(duration: 0.1)) {

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -23,7 +23,7 @@ struct PublicationDetail: View {
 
     private func fetch() {
         cancellableIDQuery = Network.shared.publisher(for: GetPublicationBySlugQuery(slug: publication.slug))
-            .map { $0.publication.map{ $0.fragments.publicationFields.id }! }
+            .map { $0.publication.map({ $0.fragments.publicationFields.id })! }
             .sink {
                 if case let .failure(error) = $0 {
                     print("GetPublicationBySlugQuery failed: \(error)")

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetailHeader.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetailHeader.swift
@@ -90,7 +90,6 @@ struct PublicationDetailHeader: View {
                     userData.isPublicationFollowed(publication) ?
                         VolumeEvent.followPublication.toEvent(.publication, value: publication.id, navigationSource: navigationSource) :
                         VolumeEvent.unfollowPublication.toEvent(.publication, value: publication.id, navigationSource: navigationSource)
-
                 )
             }
         }


### PR DESCRIPTION
## Overview

Opening a publication detail page from an article fails to load articles. I fixed that bug. 

## Changes Made
- Changed request sequence for `PublicationDetail`
  - The reason is that `Article` objects contain an embedded `Publication` object with an `id` field that doesn't match the `id` of publications returned by `getAllPublications`. MongoDB considers the base publications and embedded publications as separate objects & automatically assigns them different `id`s, so we opted to use the `slug` queries instead. 
  - New sequence: 
    1. get slug from publication embedded in article
    2. get publication by that slug
    3. query the articles using the id from the base publication
- Turned off Firebase Analytics debug messages

## Test Coverage
- Play tested on iPhone 11 Pro

## Next Steps
- Change queries to use `getArticlesByPublicationSlug` when backend supports that method
