### PR TITLE
Add loading indicator to WebView

### DIFF
--- a/Volume/Supporting Views/WebView.swift
+++ b/Volume/Supporting Views/WebView.swift
@@ -28,21 +28,20 @@ struct WebView: UIViewRepresentable {
 }
 
 class LoadingWebView: WKWebView {
-    var loadingIndicator: UIActivityIndicatorView!
+    let loadingIndicator = UIActivityIndicatorView()
 
     init() {
         super.init(frame: .zero, configuration: WKWebViewConfiguration())
-        self.navigationDelegate = self
+        navigationDelegate = self
 
-        loadingIndicator = UIActivityIndicatorView()
         loadingIndicator.hidesWhenStopped = true
         loadingIndicator.style = .medium
         loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(loadingIndicator)
+        addSubview(loadingIndicator)
 
         NSLayoutConstraint.activate([
-            loadingIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            loadingIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+            loadingIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+            loadingIndicator.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
     }
 

--- a/Volume/Supporting Views/WebView.swift
+++ b/Volume/Supporting Views/WebView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Cornell AppDev. All rights reserved.
 //
 import SwiftUI
+import UIKit
 import WebKit
 
 struct WebView: UIViewRepresentable {
@@ -16,7 +17,7 @@ struct WebView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let webView = WKWebView()
+        let webView = LoadingWebView()
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -24,4 +25,42 @@ struct WebView: UIViewRepresentable {
     func updateUIView(_ uiView: WKWebView, context: Context) { }
 
     class Coordinator: NSObject { }
+}
+
+class LoadingWebView: WKWebView {
+    var loadingIndicator: UIActivityIndicatorView!
+
+    init() {
+        super.init(frame: .zero, configuration: WKWebViewConfiguration())
+        self.navigationDelegate = self
+
+        loadingIndicator = UIActivityIndicatorView()
+        loadingIndicator.hidesWhenStopped = true
+        loadingIndicator.style = .medium
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(loadingIndicator)
+
+        NSLayoutConstraint.activate([
+            loadingIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            loadingIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension LoadingWebView: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loadingIndicator.stopAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        loadingIndicator.startAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loadingIndicator.stopAnimating()
+    }
 }


### PR DESCRIPTION
## Overview

Added loading circle indicator to `WebView`

## Changes Made

Created `LoadingWebView` subclass & added to `WebView`

## Test Coverage

Play tested on iPhone 11 Pro

## Next Steps

Detect scrolling in BrowserView & minimize top & bottom bars. 

## Screenshots

Loading indicator stays until the entire website is loaded.  

<details>
<summary> Loading indicator on basic web page </summary>
<br>

![IMG_1429](https://user-images.githubusercontent.com/13712511/156690054-fd1cd68d-3313-4b1c-ac74-89dcc8b7d6b5.PNG)

</details>


<details>
<summary> Loading indicator on complex web page </summary>
<br>

![IMG_1430](https://user-images.githubusercontent.com/13712511/156690058-5278fb45-148f-4c58-8ae5-1bff0d81ad00.PNG)

</details>
