### PR TITLE
Standardize error messages

### DIFF
--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("UIApplicationDelegate didRegisterForRemoteNotifications with error: \(error.localizedDescription)")
+        print("Error: UIApplicationDelegate didFailToRegisterForRemoteNotificationsWithError: \(error.localizedDescription)")
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -29,7 +29,7 @@ class Notifications: NSObject, ObservableObject {
                         let event = VolumeEvent.enableNotification.toEvent(.notification, value: "", navigationSource: .unspecified)
                         AppDevAnalytics.log(event)
                     } else if let error = error {
-                        print("Error requesting push notification permissions: \(error)")
+                        print("Error: failed to obtain push notification permissions: \(error.localizedDescription)")
                     }
                 }
             }

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -62,7 +62,7 @@ class UserData: ObservableObject {
             if let encoded = try? JSONEncoder().encode(newValue) {
                 UserDefaults.standard.set(encoded, forKey: weeklyDebriefKey)
             } else {
-                print("Error: failed to encode WeeklyDebrief object and UserData.weeklyDebrief property not set.")
+                print("Error: failed to encode WeeklyDebrief object")
             }
         }
     }
@@ -139,7 +139,7 @@ class UserData: ObservableObject {
             cancellables[.bookmark(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid))
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { _ in
                     if !self.savedArticleIDs.contains(article.id) {
@@ -173,7 +173,7 @@ class UserData: ObservableObject {
             cancellables[.follow(publication)] = Network.shared.publisher(for: mutation)
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: FollowPublicationMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { value in
                     if !self.followedPublicationIDs.contains(publication.id) {
@@ -188,7 +188,7 @@ class UserData: ObservableObject {
             cancellables[.unfollow(publication)] = Network.shared.publisher(for: UnfollowPublicationMutation(publicationID: publication.id, uuid: uuid))
                 .sink { completion in
                     if case let .failure(error) = completion {
-                        print(error)
+                        print("Error: UnfollowPublicationMutation failed on UserData: \(error.localizedDescription)")
                     }
                 } receiveValue: { _ in
                     self.followedPublicationIDs.removeAll(where: { $0 == publication.id })

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -176,7 +176,7 @@ struct BrowserView: View {
         cancellableShoutoutMutation = Network.shared.publisher(for: IncrementShoutoutsMutation(id: article.id, uuid: uuid))
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: IncrementShoutoutsMutation failed on BrowserView: \(error.localizedDescription)")
                 }
             }, receiveValue: { _ in })
     }
@@ -186,7 +186,7 @@ struct BrowserView: View {
         cancellableArticleQuery = Network.shared.publisher(for: GetArticleByIdQuery(id: id))
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: GetArticleByIdQuery failed on BrowserView: \(error.localizedDescription)")
                 }
             } receiveValue: { article in
                 if let fields = article.article?.fragments.articleFields {
@@ -201,7 +201,7 @@ struct BrowserView: View {
         cancellableReadMutation = Network.shared.publisher(for: ReadArticleMutation(id: id, uuid: uuid))
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: ReadArticleMutation failed on BrowserView: \(error.localizedDescription)")
                 }
             } receiveValue: { _ in }
     }

--- a/Volume/Views/DebriefArticleView.swift
+++ b/Volume/Views/DebriefArticleView.swift
@@ -56,7 +56,6 @@ struct DebriefArticleView: View {
         Button {
             incrementShoutouts(for: article)
         } label: {
-            let _ = print("the shoutouts is \(max(article.shoutouts, userData.shoutoutsCache[article.id, default: 0]))")
             Image("shout-out")
                 .resizable()
                 .foregroundColor(max(article.shoutouts, userData.shoutoutsCache[article.id, default: 0]) > 0 ? Color.white : Color.volume.orange)
@@ -130,7 +129,7 @@ struct DebriefArticleView: View {
         cancellableShoutoutMutation = Network.shared.publisher(for: IncrementShoutoutsMutation(id: article.id, uuid: uuid))
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: IncrementShoutoutsMutation failed on DebriefArticleView: \(error.localizedDescription)")
                 }
             }, receiveValue: { _ in })
     }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -85,7 +85,7 @@ struct HomeList: View {
             .map(\.user.weeklyDebrief)
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print(error)
+                    print("Error: GetWeeklyDebriefQuery failed on HomeList: \(error.localizedDescription)")
                 }
             } receiveValue: { weeklyDebrief in
                 userData.weeklyDebrief = WeeklyDebrief(from: weeklyDebrief)
@@ -125,7 +125,6 @@ struct HomeList: View {
             case .reloading, .results:
                 Button {
                     isWeeklyDebriefOpen = true
-                    let _ = print("opening ")
                 } label: {
                     ZStack(alignment: .leading) {
                         Image("weekly-debrief-curves")

--- a/Volume/Views/Onboarding/FollowView.swift
+++ b/Volume/Views/Onboarding/FollowView.swift
@@ -21,7 +21,7 @@ extension OnboardingView {
                 .map { data in data.publications.compactMap { $0.fragments.publicationFields } }
                 .sink(receiveCompletion: { completion in
                     if case let .failure(error) = completion {
-                        print(error.localizedDescription)
+                        print("Error: GetAllPublicationsQuery failed on FollowView: \(error.localizedDescription)")
                     }
                 }, receiveValue: { value in
                     state = .results([Publication](value))

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -146,7 +146,7 @@ struct OnboardingView: View {
             .map { $0.user.uuid }
             .sink { completion in
                 if case let .failure(error) = completion {
-                    print("An error occurred while creating user: \(error)")
+                    print("Error: failed to create user: \(error.localizedDescription)")
                 }
             } receiveValue: { uuid in
                 userData.uuid = uuid

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -25,7 +25,7 @@ struct PublicationDetail: View {
             .map(\.articles)
             .sink(receiveCompletion: { completion in
                 if case let .failure(error) = completion {
-                    print(error.localizedDescription)
+                    print("Error: GetArticlesByPublicationIdQuery failed on PublicationDetail: \(error.localizedDescription)")
                 }
             }, receiveValue: { value in
                 withAnimation(.linear(duration: 0.1)) {


### PR DESCRIPTION
## Overview

Standardized printed error messages across the repo. 

## Changes Made

The new standard error format: 
- for network requests: `Error: NameOfQuery failed on NameOfCurrentScreen: \(error.localizedDescription)`
- for other errors: `Error: <description of attempted action> failed: \(error.localizedDescription)`

## Next Steps

These changes revealed a few issues that will be fixed next: 
- The `getWeeklyDebrief`, `bookmarkArticle`, and `readArticle` methods have not been implemented on backend and thus need to be temporarily removed. 
- Some requests such as `getWeeklyDebrief` are being made (and fail) twice
