### PR TITLE
Volume Message Fixes

### DIFF
--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -11,10 +11,11 @@ import SwiftUI
 enum Message {
     case noBookmarks
     case upToDate
+    case noFollowing
 
     var title: String {
         switch self {
-        case .noBookmarks:
+        case .noBookmarks, .noFollowing:
             return "Nothing to see here!"
         case .upToDate:
             return "You're up to date!"
@@ -25,6 +26,8 @@ enum Message {
         switch self {
         case .noBookmarks:
             return "You have no saved articles"
+        case .noFollowing:
+            return "Follow some student publications that you are interested in"
         case .upToDate:
             return "You've seen all new articles from the publications you're following."
         }
@@ -33,15 +36,16 @@ enum Message {
 
 struct VolumeMessage: View {
     @State var message: Message
+    @State var largeFont : Bool
 
     var body: some View {
         VStack(spacing: 10) {
-            Image("volume-logo")
+            Image.volume.feed
                 .foregroundColor(.volume.orange)
             Text(message.title)
-                .font(.newYorkMedium(size: 12))
+                .font(.newYorkMedium(size: largeFont ? 24 : 18))
             Text(message.subtitle)
-                .font(.helveticaRegular(size: 10))
+                .font(.helveticaRegular(size: 12))
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
         }
@@ -51,6 +55,6 @@ struct VolumeMessage: View {
 
 struct VolumeMessage_Previews: PreviewProvider {
     static var previews: some View {
-        VolumeMessage(message: .upToDate)
+        VolumeMessage(message: .upToDate, largeFont: false)
     }
 }

--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -11,12 +11,15 @@ import SwiftUI
 enum Message {
     case noBookmarks
     case upToDate
-    case noFollowing
+    case noFollowingHome
+    case noFollowingPublications
 
     var title: String {
         switch self {
-        case .noBookmarks, .noFollowing:
+        case .noBookmarks, .noFollowingHome:
             return "Nothing to see here!"
+        case .noFollowingPublications:
+            return "No Followed Publications"
         case .upToDate:
             return "You're up to date!"
         }
@@ -26,8 +29,10 @@ enum Message {
         switch self {
         case .noBookmarks:
             return "You have no saved articles"
-        case .noFollowing:
+        case .noFollowingHome:
             return "Follow some student publications that you are interested in"
+        case .noFollowingPublications:
+            return "Follow some below and we'll show them up here"
         case .upToDate:
             return "You've seen all new articles from the publications you're following."
         }
@@ -37,6 +42,7 @@ enum Message {
 struct VolumeMessage: View {
     @State var message: Message
     @State var largeFont : Bool
+    @State var fullWidth : Bool
 
     var body: some View {
         VStack(spacing: 10) {
@@ -49,12 +55,12 @@ struct VolumeMessage: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
         }
-        .frame(width: largeFont ? nil : 205, height: 100)
+        .frame(width: fullWidth ? nil : 205, height: 100)
     }
 }
 
 struct VolumeMessage_Previews: PreviewProvider {
     static var previews: some View {
-        VolumeMessage(message: .upToDate, largeFont: false)
+        VolumeMessage(message: .upToDate, largeFont: false, fullWidth: false)
     }
 }

--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -49,7 +49,7 @@ struct VolumeMessage: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
         }
-        .frame(width: 205, height: 100)
+        .frame(width: largeFont ? nil : 205, height: 100)
     }
 }
 

--- a/Volume/Views/MainView/BookmarksList.swift
+++ b/Volume/Views/MainView/BookmarksList.swift
@@ -73,7 +73,7 @@ struct BookmarksList: View {
                 } else {
                     VStack {
                         Spacer(minLength: geometry.size.height / 5)
-                        VolumeMessage(message: .noBookmarks)
+                        VolumeMessage(message: .noBookmarks, largeFont: true)
                     }
                 }
             }

--- a/Volume/Views/MainView/BookmarksList.swift
+++ b/Volume/Views/MainView/BookmarksList.swift
@@ -73,7 +73,7 @@ struct BookmarksList: View {
                 } else {
                     VStack {
                         Spacer(minLength: geometry.size.height / 5)
-                        VolumeMessage(message: .noBookmarks, largeFont: true)
+                        VolumeMessage(message: .noBookmarks, largeFont: true, fullWidth: true)
                     }
                 }
             }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -183,11 +183,11 @@ struct HomeList: View {
             Spacer()
 
             if someFollowedArticles {
-                VolumeMessage(message: .upToDate, largeFont: false)
+                VolumeMessage(message: .upToDate, largeFont: false, fullWidth: false)
                     .padding(.top, 25)
                     .padding(.bottom, -5)
             } else {
-                VolumeMessage(message: .noFollowing, largeFont: false)
+                VolumeMessage(message: .noFollowingHome, largeFont: false, fullWidth: false)
                     .padding(.top, 25)
                     .padding(.bottom, -5)
             }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -75,6 +75,15 @@ struct HomeList: View {
             fetchWeeklyDebrief()
         }
     }
+
+    private var someFollowedArticles: Bool {
+        switch state {
+        case .loading:
+            return userData.followedPublicationIDs.count > 0
+        case .reloading(let results), .results(let results):
+            return results.followedArticles.count > 0
+        }
+    }
     
     private func fetchWeeklyDebrief() {
         guard let uuid = userData.uuid else {
@@ -170,10 +179,18 @@ struct HomeList: View {
                     }
                 }
             }
+
             Spacer()
-            VolumeMessage(message: .upToDate)
-                .padding(.top, 25)
-                .padding(.bottom, -5)
+
+            if someFollowedArticles {
+                VolumeMessage(message: .upToDate, largeFont: false)
+                    .padding(.top, 25)
+                    .padding(.bottom, -5)
+            } else {
+                VolumeMessage(message: .noFollowing, largeFont: false)
+                    .padding(.top, 25)
+                    .padding(.bottom, -5)
+            }
         }
     }
     

--- a/Volume/Views/MainView/PublicationList.swift
+++ b/Volume/Views/MainView/PublicationList.swift
@@ -80,17 +80,7 @@ struct PublicationList: View {
                     }
                 }
             } else {
-                VStack(spacing: 10) {
-                    Text("You're not following any publications")
-                        .lineLimit(2)
-                        .font(.helveticaNeueMedium(size: 16))
-                    Text("Follow some below and we'll show them up here")
-                        .lineLimit(2)
-                        .font(.helveticaRegular(size: 12))
-                        .foregroundColor(Color(white: 151 / 255))
-                }
-                .padding()
-                .frame(height: 135)
+                VolumeMessage(message: .noFollowingPublications, largeFont: false, fullWidth: true)
             }
         }
     }


### PR DESCRIPTION
## Overview

Updated the font and sizing of the Volume messages



## Changes Made

- Remove hard coded strings and replaced with cases in Volume Messages
- Replaced image of Volume Message with the feed logo
- Add a `largeFont` and `fullWidth` variable to adapt to the different design requirements of the messages



## Test Coverage

- Test on iPhone XR


## Screenshots (delete if not applicable)


<details>

  <summary>No Following - Home</summary>


  ![IMG_3250](https://user-images.githubusercontent.com/57964367/158869666-58ecdb8a-ab37-4a01-96c9-93016140493d.PNG)
  

</details>

<details>

  <summary>Following - Home</summary>

   ![IMG_3251](https://user-images.githubusercontent.com/57964367/158869631-68351f70-6b3e-4b5d-be47-fab36bb1bfc9.PNG)
  

</details>

<details>

  <summary>Bookmarks</summary>

     
   ![IMG_639245CCB466-1](https://user-images.githubusercontent.com/57964367/158869772-c4de0c69-3bf9-4794-81d6-b011ef1397da.jpeg)


</details>

<details>

  <summary>No Following - Publications</summary>

     
![IMG_2950EC1A6888-1](https://user-images.githubusercontent.com/57964367/158869940-e731503b-9316-4349-bfe8-6cd2fb2dd177.jpeg)



</details>
