### PR TITLE
Implement Background Gray

### DIFF
--- a/Volume/Extensions/Color+Extension.swift
+++ b/Volume/Extensions/Color+Extension.swift
@@ -20,5 +20,7 @@ extension Color {
         let orange = Color(red: 208 / 255, green: 112 / 255, blue: 0 / 255)
         let lightOrange = Color(red: 255 / 255, green: 239 / 255, blue: 220 / 255)
         let shadowBlack = Color(white: 10 / 255, opacity: 0.10)
+        /// Color used for background of tabBar and view
+        let backgroundGray = Color(white: 245 / 255)
     }
 }

--- a/Volume/Views/MainView/BookmarksList.swift
+++ b/Volume/Views/MainView/BookmarksList.swift
@@ -79,7 +79,7 @@ struct BookmarksList: View {
             }
             .disabled(state == .loading)
             .padding(.top)
-            .background(Color.white)
+            .background(Color.volume.backgroundGray)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     BubblePeriodText("Bookmarks")

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -20,6 +20,21 @@ struct HomeList: View {
     @EnvironmentObject private var notifications: Notifications
     @EnvironmentObject private var userData: UserData
 
+    init() {
+        let coloredAppearance = UINavigationBarAppearance()
+        coloredAppearance.configureWithTransparentBackground()
+        coloredAppearance.backgroundColor = UIColor(Color.volume.backgroundGray)
+        coloredAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        coloredAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
+
+        UINavigationBar.appearance().standardAppearance = coloredAppearance
+        UINavigationBar.appearance().compactAppearance = coloredAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = coloredAppearance
+        UINavigationBar.appearance().compactAppearance = coloredAppearance
+
+        UINavigationBar.appearance().tintColor = .white
+    }
+
     private func fetchContent(_ done: @escaping () -> Void = { }) {
         guard state.isLoading else { return }
 
@@ -220,7 +235,7 @@ struct HomeList: View {
         }
         .disabled(state.shouldDisableScroll)
         .padding(.top)
-        .background(Color.white)
+        .background(Color.volume.backgroundGray)
         .toolbar {
             ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
                 Image.volume.logo

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -24,15 +24,11 @@ struct HomeList: View {
         let coloredAppearance = UINavigationBarAppearance()
         coloredAppearance.configureWithTransparentBackground()
         coloredAppearance.backgroundColor = UIColor(Color.volume.backgroundGray)
-        coloredAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-        coloredAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
 
         UINavigationBar.appearance().standardAppearance = coloredAppearance
         UINavigationBar.appearance().compactAppearance = coloredAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = coloredAppearance
         UINavigationBar.appearance().compactAppearance = coloredAppearance
-
-        UINavigationBar.appearance().tintColor = .white
     }
 
     private func fetchContent(_ done: @escaping () -> Void = { }) {

--- a/Volume/Views/MainView/MagazinesList.swift
+++ b/Volume/Views/MainView/MagazinesList.swift
@@ -102,6 +102,7 @@ struct MagazinesList: View {
             }
             .disabled(state.shouldDisableScroll)
             .padding(.top)
+            .background(Color.volume.backgroundGray)
             .toolbar {
                 ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
                     BubblePeriodText("Magazines")

--- a/Volume/Views/MainView/PublicationList.swift
+++ b/Volume/Views/MainView/PublicationList.swift
@@ -142,7 +142,7 @@ struct PublicationList: View {
             }
             .disabled(state.shouldDisableScroll)
             .padding(.top)
-            .background(Color.white)
+            .background(Color.volume.backgroundGray)
             .toolbar {
                 ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
                     BubblePeriodText("Publications")

--- a/Volume/Views/SettingsView.swift
+++ b/Volume/Views/SettingsView.swift
@@ -16,7 +16,9 @@ struct SettingsView: View {
     ]
     
     init() {
-        UINavigationBar.appearance().titleTextAttributes = [.font : UIFont.newYorkMedium(size: 20)]
+        UINavigationBar.appearance().titleTextAttributes = [
+            .font : UIFont.newYorkMedium(size: 20),
+        ]
     }
     
     static func getView(for view: NestedSettingsView) -> some View {


### PR DESCRIPTION

## Overview

Replace the background color of the view and of tab bar to be consistent with the light gray that is consistent with design. It allows distinguishing between white background of the publication logo. 



## Changes Made

- Replace background color of view
- Create custom UITabBar apperance that is initialized on HomeList (landing view) and the state is propogated to all of the other views.

## Test Coverage

- iPhone 13 on Simulator
- iPhone XR actual device

## Screenshots (delete if not applicable)

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/57964367/159804663-299fd2f8-ac1c-41dc-91c5-35bfc6d01877.PNG" ></td>
    <td><img src="https://user-images.githubusercontent.com/57964367/159804596-ab551c14-2ecd-49a3-a668-acb1e434ea07.PNG" ></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/57964367/159804818-46d5ed24-b956-432d-ab43-dc8ca53a3b72.PNG" ></td>
    <td><img src="https://user-images.githubusercontent.com/57964367/159804781-6c0335e4-9f06-4ac7-8c8f-501d2468c7c3.PNG" ></td>
  </tr>
 </table>