### PR TITLE
Minor UI Fixes

### DIFF
--- a/Volume/View Models/ArticleInfo.swift
+++ b/Volume/View Models/ArticleInfo.swift
@@ -22,6 +22,7 @@ struct ArticleInfo: View {
                     Text(article.publication.name)
                         .font(largeFont ? .newYorkMedium(size: 16) : .newYorkMedium(size: 12))
                         .padding(.bottom, largeFont ? 3.5 : 1.5)
+                        .multilineTextAlignment(.leading)
                 }
 
                 Text(article.title)

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -95,7 +95,7 @@ struct BrowserView: View {
                     VStack {
                         Text(navigationTitle)
                             .font(.newYorkBold(size: 12))
-                            .truncationMode(.middle)
+                            .truncationMode(.tail)
                         Text("Reading in Volume")
                             .font(.helveticaRegular(size: 10))
                             .foregroundColor(.volume.lightGray)

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -95,11 +95,12 @@ struct BrowserView: View {
                     VStack {
                         Text(navigationTitle)
                             .font(.newYorkBold(size: 12))
-                            .fixedSize()
+                            .truncationMode(.middle)
                         Text("Reading in Volume")
                             .font(.helveticaRegular(size: 10))
                             .foregroundColor(.volume.lightGray)
                     }
+                    .padding(.horizontal, 48)
                 } else {
                     Text(navigationTitle)
                         .font(.newYorkBold(size: 10))

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -105,7 +105,7 @@ struct HomeList: View {
     private var trendingArticlesSection: some View {
         Group {
             Header("The Big Read")
-                .padding([.top, .leading, .trailing])
+                .padding([.top, .horizontal])
             ScrollView(.horizontal, showsIndicators: false) {
                 switch state {
                 case .loading:

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -131,8 +131,10 @@ struct PublicationDetail: View {
                 case .results(let articles):
                     LazyVStack {
                         ForEach(articles) { article in
-                            ArticleRow(article: article, navigationSource: navigationSource, showsPublicationName: false)
-                                .padding([.bottom, .leading, .trailing])
+                            NavigationLink(destination: BrowserView(initType: .readyForDisplay(article), navigationSource: navigationSource)) {
+                                ArticleRow(article: article, navigationSource: navigationSource, showsPublicationName: false)
+                                    .padding([.bottom, .leading, .trailing])
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixed title on BrowserView overflowing and the reminants of an alignment issue that appeared out of nowhere.


## Overview

- Add padding to title of BrowserView
- Fix alignment in cases of show publication and not show publication


## Changes Made

- Since the top bar of the BrowserView was implemented using a ZStack we had to ensure the title text was not longer than the button (leftArrow and compass) placed beneath it. Thus I added a padding based on the computed sizes of the buttons (plus some slack for nicer spacing)


## Test Coverage

- Tested on Simulator iPhone 13


## Screenshots (delete if not applicable)

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/57964367/159944812-cdc8b45d-952f-496b-8f42-eb14fdbb2a38.png" ></td>
    <td><img src="https://user-images.githubusercontent.com/57964367/159944887-626fa1a0-2613-4e43-baf0-7e7ab610ac93.png" ></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/57964367/159944945-081c3e49-f9b6-4eca-8793-73186ddb632e.png" ></td>
    <td><img src="https://user-images.githubusercontent.com/57964367/159945014-4be4f021-4375-4beb-8b7b-63ead64fa82d.png" ></td>
  </tr>
 </table>
