### PR TITLE
Implement Notifications w/ Firebase Messaging

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,5 +12,6 @@ target 'Volume' do
   pod 'SDWebImageSVGCoder'
   pod 'SwiftUIRefresh'
   pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/analytics-ios.git', :commit => '5d459c0475'
+  pod 'Firebase/Messaging'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,6 +12,9 @@ PODS:
     - FirebaseAnalytics (= 7.7.0)
   - Firebase/CoreOnly (7.7.0):
     - FirebaseCore (= 7.7.0)
+  - Firebase/Messaging (7.7.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 7.7.0)
   - FirebaseAnalytics (7.7.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
@@ -35,6 +38,18 @@ PODS:
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
+  - FirebaseInstanceID (7.11.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
+  - FirebaseMessaging (7.7.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstanceID (~> 7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Reachability (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
   - GoogleAppMeasurement (7.7.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
@@ -85,6 +100,7 @@ DEPENDENCIES:
   - Apollo
   - AppDevAnalytics (from `https://github.com/cuappdev/analytics-ios.git`, commit `5d459c0475`)
   - AppDevAnnouncements (from `https://github.com/cuappdev/appdev-announcements.git`)
+  - Firebase/Messaging
   - SDWebImageSVGCoder
   - SDWebImageSwiftUI
   - SwiftUIRefresh
@@ -97,6 +113,8 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseInstallations
+    - FirebaseInstanceID
+    - FirebaseMessaging
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
@@ -132,6 +150,8 @@ SPEC CHECKSUMS:
   FirebaseCore: ac35d680a0bf32319a59966a1478e0741536b97b
   FirebaseCoreDiagnostics: 3d36e05da74cb8b7ce30e6594a8f201b982c725c
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
+  FirebaseInstanceID: ad5135045a498d7775903efd39762d2cdfa1be27
+  FirebaseMessaging: ce33c2537fdda1d1a4bc82b2245e3c3bf9107684
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384
   GoogleDataTransport: 8b0e733ea77c9218778e5a9e34ba9508b8328939
   GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
@@ -143,6 +163,6 @@ SPEC CHECKSUMS:
   SDWebImageSwiftUI: 8a3923c95108312b03a599ec1498754af55a6819
   SwiftUIRefresh: ca6ae2718d25aad5dd68bbf5d2ae36ef6ade98bf
 
-PODFILE CHECKSUM: e4a4d1e46ade3c4fdd42cda7055692b0f7bc4a65
+PODFILE CHECKSUM: c0cfaa68eab758db43a05ebddeeaf9853d7e439f
 
 COCOAPODS: 1.11.2

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -32,14 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Messaging.messaging().apnsToken = deviceToken
         let deviceTokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("UIApplicationDelegate didRegisterForRemoteNotifications with deviceToken: \(deviceTokenString)")
-        UserData.shared.deviceToken = deviceTokenString
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("Error: UIApplicationDelegate didFailToRegisterForRemoteNotificationsWithError: \(error.localizedDescription)")
-        #if DEBUG
-        UserData.shared.deviceToken = "debugSimulatorDeviceToken"
-        #endif
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
@@ -68,13 +64,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 }
-
-//extension AppDelegate: UNUserNotificationCenterDelegate {
-//    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-//        <#code#>
-//    }
-//
-//    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-//        <#code#>
-//    }
-//}

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import AppDevAnalytics
+import FirebaseMessaging
 import SDWebImageSVGCoder
 import SwiftUI
 import UIKit
@@ -28,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
         let deviceTokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("UIApplicationDelegate didRegisterForRemoteNotifications with deviceToken: \(deviceTokenString)")
         UserData.shared.deviceToken = deviceTokenString
@@ -66,3 +68,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 }
+
+//extension AppDelegate: UNUserNotificationCenterDelegate {
+//    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+//        <#code#>
+//    }
+//
+//    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+//        <#code#>
+//    }
+//}

--- a/Volume/Supporting/Info.plist
+++ b/Volume/Supporting/Info.plist
@@ -77,6 +77,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 </dict>

--- a/Volume/Supporting/Main.swift
+++ b/Volume/Supporting/Main.swift
@@ -26,6 +26,7 @@ struct Main: App {
 
     private func configureFirebase() {
         FirebaseApp.configure()
+        FirebaseConfiguration.shared.setLoggerLevel(.min)
         AnnouncementNetworking.setupConfig(
             scheme: Secrets.announcementsScheme,
             host: Secrets.announcementsHost,

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -14,7 +14,7 @@ import UserNotifications
 class Notifications: NSObject, ObservableObject {
     static let shared = Notifications()
     private let center = UNUserNotificationCenter.current()
-    private let firebaseMessaging = Messaging.messaging()
+    let firebaseMessaging = Messaging.messaging()
     @Published var isWeeklyDebriefOpen = false
     
     private override init() {
@@ -47,6 +47,7 @@ class Notifications: NSObject, ObservableObject {
     }
     
     func handlePushNotification(userInfo: [AnyHashable: Any]) {
+        print("userInfo: \(userInfo)")
         guard let notificationType = userInfo["notificationType"] as? String
         else {
             print("Error: data or notificationType not found in push notification payload")

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -47,7 +47,9 @@ class Notifications: NSObject, ObservableObject {
     }
     
     func handlePushNotification(userInfo: [AnyHashable: Any]) {
-        print("userInfo: \(userInfo)")
+        #if DEBUG
+        print("Notification payload userInfo: \(userInfo)")
+        #endif
         guard let notificationType = userInfo["notificationType"] as? String
         else {
             print("Error: data or notificationType not found in push notification payload")
@@ -91,8 +93,15 @@ extension Notifications {
 
 extension Notifications: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        if let fcmToken = fcmToken {
+            print("Firebase Messaging registration token: \(fcmToken)")
+            UserData.shared.fcmToken = fcmToken
+        } else {
+            print("Error: Firebase Messaging failed to register")
+            UserData.shared.fcmToken = "debugSimulatorFCMToken"
+        }
+        
         let tokenDict = ["token": fcmToken ?? ""]
-        print("Firebase Messaging registration token: \(fcmToken ?? "")")
         NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil,userInfo: tokenDict)
     }
 }

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -7,18 +7,20 @@
 //
 
 import AppDevAnalytics
-import Foundation
+import FirebaseMessaging
 import SwiftUI
 import UserNotifications
 
 class Notifications: NSObject, ObservableObject {
     static let shared = Notifications()
     private let center = UNUserNotificationCenter.current()
+    private let firebaseMessaging = Messaging.messaging()
     @Published var isWeeklyDebriefOpen = false
     
     private override init() {
         super.init()
         center.delegate = self
+        firebaseMessaging.delegate = self
     }
     
     func requestAuthorization() {
@@ -83,5 +85,13 @@ extension Notifications {
     private enum NotificationType: String {
         case newArticle = "new_article"
         case weeklyDebrief = "weekly_debrief"
+    }
+}
+
+extension Notifications: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        let tokenDict = ["token": fcmToken ?? ""]
+        print("Firebase Messaging registration token: \(fcmToken ?? "")")
+        NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil,userInfo: tokenDict)
     }
 }

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -16,7 +16,7 @@ class UserData: ObservableObject {
     private let publicationsKey = "savedPublicationIds"
     private let articleShoutoutsKey = "articleShoutoutsCounter"
     private let isFirstLaunchKey = "isFirstLaunch"
-    private let deviceTokenKey = "deviceToken"
+    private let fcmTokenKey = "fcmToken"
     private let userUUIDKey = "userUUID"
     private let weeklyDebriefKey = "weeklyDebrief"
 
@@ -67,9 +67,9 @@ class UserData: ObservableObject {
         }
     }
     
-    var deviceToken: String? = nil {
+    var fcmToken: String? = nil {
         willSet {
-            UserDefaults.standard.setValue(newValue, forKey: deviceTokenKey)
+            UserDefaults.standard.setValue(newValue, forKey: fcmTokenKey)
         }
     }
     
@@ -93,8 +93,8 @@ class UserData: ObservableObject {
             weeklyDebrief = debrief
         }
         
-        if let deviceToken = UserDefaults.standard.object(forKey: deviceTokenKey) as? String {
-            self.deviceToken = deviceToken
+        if let fcmToken = UserDefaults.standard.object(forKey: fcmTokenKey) as? String {
+            self.fcmToken = fcmToken
         }
         
         if let uuid = UserDefaults.standard.object(forKey: userUUIDKey) as? String {

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -137,13 +137,13 @@ struct OnboardingView: View {
     // MARK: Actions
     
     private func createUser() {
-        // TODO: change to use firebase
-        guard let deviceToken = userData.deviceToken else {
-            print("Error: received nil for deviceToken from UserData")
+        guard let fcmToken = userData.fcmToken else {
+            print("Error: received nil for fcmToken from UserData")
             return
         }
         
-        cancellableCreateUserMutation = Network.shared.publisher(for: CreateUserMutation(deviceToken: deviceToken, followedPublicationIDs: userData.followedPublicationIDs))
+        // TODO: change parameter name after new API is live
+        cancellableCreateUserMutation = Network.shared.publisher(for: CreateUserMutation(deviceToken: fcmToken, followedPublicationIDs: userData.followedPublicationIDs))
             .map { $0.user.uuid }
             .sink { completion in
                 if case let .failure(error) = completion {

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -137,6 +137,7 @@ struct OnboardingView: View {
     // MARK: Actions
     
     private func createUser() {
+        // TODO: change to use firebase
         guard let deviceToken = userData.deviceToken else {
             print("Error: received nil for deviceToken from UserData")
             return


### PR DESCRIPTION
## Overview

Implement push notifications using Firebase Cloud Messaging.

## Changes Made
- add pod 'Firebase/Messaging'
- implement messaging delegate functions in `Notifications`
- replace instances of `deviceToken` with `fcmToken` in `UserData` 

## Test Coverage
- Sent test notification from Firebase console
- Manually pinged test notification from backend
- Ensured `createUser` still works on simulator

## Next Steps
- Merge this PR w/ release branch to test notifs in prod environment

## Screenshots

<details>

  <summary>Test Notification from Firebase Console</summary>

<img src="https://user-images.githubusercontent.com/13712511/160031988-0dc2ef3e-df2e-4c4b-9734-4f2e087e88b7.PNG" width=300>

</details>

<details>

  <summary>Test Notification from volume-backend</summary>

<img src="https://user-images.githubusercontent.com/13712511/160031562-eac579fb-00da-4918-a2dd-295087140820.PNG" width=300>

</details>
