### PR TITLE
Reconcile changes from PRs #89 & #93

### DIFF
--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -123,15 +123,6 @@ struct HomeList: View {
                 }
             }
     }
-
-    private var isFollowingPublications: Bool {
-        switch sectionStates.followedArticles {
-        case .loading:
-            return userData.followedPublicationIDs.count > 0
-        case .reloading(let articles), .results(let articles):
-            return articles.count > 0
-        }
-    }
     
     private func fetchWeeklyDebrief() {
         guard let uuid = userData.uuid else {
@@ -224,9 +215,18 @@ struct HomeList: View {
             switch sectionStates.followedArticles {
             case .loading:
                 let skeletonCount = userData.followedPublicationIDs.isEmpty ? 0 : 5
-                ForEach(0..<skeletonCount) { _ in
+                
+                ForEach(0..<skeletonCount, id: \.self) { _ in
                     ArticleRow.Skeleton()
                         .padding(.horizontal)
+                }
+                
+                if userData.followedPublicationIDs.isEmpty {
+                    Spacer()
+                    
+                    VolumeMessage(message: .noFollowingHome, largeFont: false, fullWidth: false)
+                        .padding(.top, 25)
+                        .padding(.bottom, -5)
                 }
             case .reloading(let articles), .results(let articles):
                 ForEach(articles) { article in
@@ -235,13 +235,13 @@ struct HomeList: View {
                             .padding(.horizontal)
                     }
                 }
+                
+                Spacer()
+                
+                VolumeMessage(message: articles.count > 0 ? .upToDate : .noFollowingHome, largeFont: false, fullWidth: false)
+                    .padding(.top, 25)
+                    .padding(.bottom, -5)
             }
-
-            Spacer()
-
-            VolumeMessage(message: isFollowingPublications ? .upToDate : .noFollowingHome, largeFont: false, fullWidth: false)
-                .padding(.top, 25)
-                .padding(.bottom, -5)
         }
     }
     
@@ -268,20 +268,19 @@ struct HomeList: View {
     var body: some View {
         RefreshableScrollView(onRefresh: { done in
             // TODO: add weekly debrief to this switch when the request stops breaking
-            switch (sectionStates.trendingArticles, sectionStates.followedArticles, sectionStates.otherArticles) {
-            case (.results(let trendingArticles), .results(let followedArticles), .results(let otherArticles)):
-                // Allow refresh when all results are done fetching.
-                sectionStates.trendingArticles = .reloading(trendingArticles)
-//                sectionStates.weeklyDebrief = .reloading(weeklyDebrief)
-                sectionStates.followedArticles = .reloading(followedArticles)
-                sectionStates.otherArticles = .reloading(otherArticles)
-                fetchContent(done)
-                return
-            default:
-                // Do nothing if at least one section isn't done fetching.
-                done()
-                return
+            if case let .results(articles) = sectionStates.trendingArticles {
+                sectionStates.trendingArticles = .reloading(articles)
             }
+            
+            if case let .results(articles) = sectionStates.followedArticles {
+                sectionStates.followedArticles = .reloading(articles)
+            }
+            
+            if case let .results(articles) = sectionStates.otherArticles {
+                sectionStates.otherArticles = .reloading(articles)
+            }
+            
+            fetchContent(done)
         }) {
             VStack(spacing: 20) {
                 trendingArticlesSection
@@ -290,7 +289,9 @@ struct HomeList: View {
                     weeklyDebriefButton
                 }
                 followedArticlesSection
+                
                 Spacer()
+                
                 otherArticlesSection
                 // Invisible navigation link only opens if application is opened
                 // through deeplink with valid article

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -125,11 +125,11 @@ struct HomeList: View {
     }
 
     private var isFollowingPublications: Bool {
-        switch state {
+        switch sectionStates.followedArticles {
         case .loading:
             return userData.followedPublicationIDs.count > 0
-        case .reloading(let results), .results(let results):
-            return results.followedArticles.count > 0
+        case .reloading(let articles), .results(let articles):
+            return articles.count > 0
         }
     }
     

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -272,13 +272,8 @@ struct HomeList: View {
                 sectionStates.trendingArticles = .reloading(articles)
             }
             
-            if case let .results(articles) = sectionStates.followedArticles {
-                sectionStates.followedArticles = .reloading(articles)
-            }
-            
-            if case let .results(articles) = sectionStates.otherArticles {
-                sectionStates.otherArticles = .reloading(articles)
-            }
+            sectionStates.followedArticles = .loading
+            sectionStates.otherArticles = .loading
             
             fetchContent(done)
         }) {

--- a/Volume/Views/MainView/PublicationList.swift
+++ b/Volume/Views/MainView/PublicationList.swift
@@ -63,7 +63,7 @@ struct PublicationList: View {
                     switch state {
                     case .loading:
                         HStack(spacing: 12) {
-                            ForEach(0..<userData.followedPublicationIDs.count) { _ in
+                            ForEach(0..<userData.followedPublicationIDs.count, id: \.self) { _ in
                                 FollowingPublicationRow.Skeleton()
                             }
                         }

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -173,7 +173,7 @@ extension OnboardingView {
 
         var body: some View {
             HStack(spacing: 12) {
-                ForEach(0..<numberOfPages) { i in
+                ForEach(0..<numberOfPages, id: \.self) { i in
                     Circle()
                         .fill(i == currentPage ? selectedColor : unselectedColor)
                         .frame(width: 6, height: 6)

--- a/Volume/Views/SettingsView.swift
+++ b/Volume/Views/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
     
     var body: some View {
         ScrollView(showsIndicators: false) {
-            ForEach(0..<SettingsView.pages.count) { index in
+            ForEach(0..<SettingsView.pages.count, id: \.self) { index in
                 SettingsPageRow(page: SettingsView.pages[index])
             }
         }


### PR DESCRIPTION
## Overview

Reconcile changes to `HomeList` made in parallel in PR #89 and PR #93, and fix compile error on `master`. 

## Changes Made

PR #89 created `isFollowingPublications`, which is a non-state variable that relies on state variable `state`. PR #93 redesigned the API for `state`. This PR reimplements PR #89 with the new API of PR #93, and fixes these bugs: 
- Refreshing `HomeList` makes the `SkeletonViews` in `followedArticlesSection` disappear. 
- Refreshing after unfollowing all publications still shows `VolumeMessage` with "You're up to date!"

Also, I changed the refresh policy to allow refresh at any time. This resolves the problem caused by the original policy of only allowing refresh when everything is loaded, as the user may be blocked from refreshing if a particular section never loads.

## Test Coverage

Play testing on iPhone 13 Pro device to make sure `VolumeMessage` still appears how it's supposed to in #89. 

## Next Steps

Ensure that PR branches are rebased with master whenever new changes appear on master. 

## Screenshots

Before (with a small change so that `master` compiles):
```swift
private var isFollowingPublications: Bool {
    switch sectionStates.followedArticles {
    case .loading:
        return userData.followedPublicationIDs.count > 0
    case .reloading(let results), .results(let results):
        return results.count > 0
    }
}
```

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/13712511/160996996-41408d82-63ca-44ee-8e2c-d8378ff007ee.MP4" ></td>
    <td><video src="https://user-images.githubusercontent.com/13712511/160996980-edca1c03-a92a-4c97-8901-8cff21b60e8c.MP4" ></td>
  </tr>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/13712511/160997006-6d656858-41ab-4499-baf7-3987a50d84a4.MP4" ></td>
    <td><video src="https://user-images.githubusercontent.com/13712511/160996987-16ece38f-ded9-4dbd-92ba-64f982b5e1d4.MP4" ></td>
  </tr>
 </table>
