### PR TITLE
Add union merge policy to .pbxproj files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pbxproj merge=union
+


### PR DESCRIPTION
## Overview

Followed [this tutorial](https://stackoverflow.com/questions/12907605/xcode-project-file-git-merge-conflict) to automatically resolve merge conflicts with `.pbxproj` files using the union method. This works because XCode removes the oldest file reference duplicates automagically. 

