### PR TITLE
Add image stretching to PublicationDetail & fix navigation colors

### DIFF
--- a/Volume/Supporting/Main.swift
+++ b/Volume/Supporting/Main.swift
@@ -19,7 +19,7 @@ struct Main: App {
         configureFirebase()
         configureNotifications()
         UINavigationBar.appearance().backgroundColor = .white
-        UINavigationBar.appearance().tintColor = UIColor(Color.black)
+        UINavigationBar.appearance().tintColor = .black
         UITabBar.appearance().barTintColor = .white
         UITabBar.appearance().clipsToBounds = true
     }

--- a/Volume/Supporting/Main.swift
+++ b/Volume/Supporting/Main.swift
@@ -19,7 +19,7 @@ struct Main: App {
         configureFirebase()
         configureNotifications()
         UINavigationBar.appearance().backgroundColor = .white
-        UINavigationBar.appearance().tintColor = UIColor(Color.volume.orange)
+        UINavigationBar.appearance().tintColor = UIColor(Color.black)
         UITabBar.appearance().barTintColor = .white
         UITabBar.appearance().clipsToBounds = true
     }

--- a/Volume/View Models/SettingsPageRow.swift
+++ b/Volume/View Models/SettingsPageRow.swift
@@ -24,6 +24,7 @@ struct SettingsPageRow: View {
                 .foregroundColor(.black)
             Spacer()
             Image.volume.backArrow
+                .foregroundColor(.black)
                 .rotationEffect(Angle(degrees: 180))
                 .padding()
         }

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -61,7 +61,7 @@ struct PublicationDetail: View {
             GeometryReader { geometry in
                 let scrollOffset = geometry.frame(in: .global).minY
                 let headerOffset = scrollOffset > 0 ? -scrollOffset : 0
-                let headerHeight = scrollOffset > 0 ? geometry.size.height + scrollOffset : geometry.size.height
+                let headerHeight = geometry.size.height + max(scrollOffset, 0)
                 
                 if let url = publication.backgroundImageUrl {
                     WebImage(url: url)
@@ -70,12 +70,12 @@ struct PublicationDetail: View {
                         .scaledToFill()
                         .frame(width: geometry.size.width, height: headerHeight)
                         .clipped()
-                        .offset(x: 0, y: headerOffset)
+                        .offset(y: headerOffset)
                 } else {
                     Rectangle() // TODO: Custom image
                         .frame(width: geometry.size.width, height: headerHeight)
                         .foregroundColor(.blue)
-                        .offset(x: 0, y: headerOffset)
+                        .offset(y: headerOffset)
                 }
             }
             .frame(height: 140)
@@ -89,7 +89,7 @@ struct PublicationDetail: View {
                             .foregroundColor(.white)
                             .padding(.top, 55)
                             .padding(.leading, 20)
-                            .shadow(color: .black, radius: 4, x: 0, y: 0)
+                            .shadow(color: .black, radius: 4)
                     }
 
                     Spacer()
@@ -101,13 +101,13 @@ struct PublicationDetail: View {
                             .clipShape(Circle())
                             .frame(width: 60, height: 60)
                             .overlay(Circle().stroke(Color.white, lineWidth: 3))
-                            .shadow(color: .volume.shadowBlack, radius: 5, x: 0, y: 0)
+                            .shadow(color: .volume.shadowBlack, radius: 5)
                             .padding(.leading, 16)
                     } else {
                         Circle()
                             .frame(width: 60, height: 60)
                             .overlay(Circle().stroke(Color.white, lineWidth: 3))
-                            .shadow(color: .volume.shadowBlack, radius: 5, x: 0, y: 0)
+                            .shadow(color: .volume.shadowBlack, radius: 5)
                             .padding(.leading, 16)
                     }
                 }

--- a/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
+++ b/Volume/Views/Onboarding/PublicationDetail/PublicationDetail.swift
@@ -59,27 +59,37 @@ struct PublicationDetail: View {
     private var backgroundImage: some View {
         ZStack {
             GeometryReader { geometry in
+                let scrollOffset = geometry.frame(in: .global).minY
+                let headerOffset = scrollOffset > 0 ? -scrollOffset : 0
+                let headerHeight = scrollOffset > 0 ? geometry.size.height + scrollOffset : geometry.size.height
+                
                 if let url = publication.backgroundImageUrl {
                     WebImage(url: url)
                         .resizable()
                         .grayBackground()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: geometry.size.width, height: 140)
+                        .scaledToFill()
+                        .frame(width: geometry.size.width, height: headerHeight)
                         .clipped()
+                        .offset(x: 0, y: headerOffset)
                 } else {
                     Rectangle() // TODO: Custom image
-                        .frame(width: geometry.size.width, height: 140)
+                        .frame(width: geometry.size.width, height: headerHeight)
                         .foregroundColor(.blue)
+                        .offset(x: 0, y: headerOffset)
                 }
             }
+            .frame(height: 140)
+            
             HStack {
                 VStack(alignment: .leading) {
                     Button(action: {
                         self.presentationMode.wrappedValue.dismiss()
                     }) {
                         Image.volume.backArrow
+                            .foregroundColor(.white)
                             .padding(.top, 55)
                             .padding(.leading, 20)
+                            .shadow(color: .black, radius: 4, x: 0, y: 0)
                     }
 
                     Spacer()
@@ -139,17 +149,17 @@ struct PublicationDetail: View {
                     }
                 }
             }
-            .edgesIgnoringSafeArea(.top)
-            .navigationBarHidden(true)
             .disabled(isLoading)
         }
+        .edgesIgnoringSafeArea(.top)
+        .navigationBarHidden(true)
         .background(Color.white)
         .gesture(
-            DragGesture().updating($dragOffset, body: { value, _, _ in
+            DragGesture().updating($dragOffset) { value, _, _ in
                 if value.startLocation.x < 20 && value.translation.width > 100 {
                     presentationMode.wrappedValue.dismiss()
                 }
-            })
+            }
         )
         .onAppear(perform: fetch)
     }


### PR DESCRIPTION
## Overview

Title. Very small PR. Made things look like their corresponding Figma designs: [https://www.figma.com/file/vMfqUmHwm9VHGChOjPQFlf/?node-id=5%3A2394](https://www.figma.com/file/vMfqUmHwm9VHGChOjPQFlf/?node-id=5%3A2394)

## Screenshots

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/13712511/163443184-0d201755-c5df-4ff4-b8ff-15cf6c9d9400.mp4" ></td>
    <td><video src="https://user-images.githubusercontent.com/13712511/163443183-d7e00734-3601-4673-9de2-417c86f76c77.mp4" ></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/13712511/163443676-16c53303-5c53-490e-a071-c93abbe3541c.png" ></td>
    <td><img src="https://user-images.githubusercontent.com/13712511/163443674-32956863-4108-41d9-8d39-747586d4d4e0.png" ></td>
  </tr>
 </table>