### PR TITLE
Networking fix for Weekly Debrief

### DIFF
--- a/Volume/Models/WeeklyDebrief.swift
+++ b/Volume/Models/WeeklyDebrief.swift
@@ -26,26 +26,4 @@ struct WeeklyDebrief: Codable {
         readArticleIDs = weeklyDebrief.readArticles.map(\.fragments.articleFields.id)
         randomArticleIDs = weeklyDebrief.randomArticles.map(\.fragments.articleFields.id)
     }
-    
-    init(creationDate: Date, expirationDate: Date, numBookmarkedArticles: Int, numReadArticles: Int, numShoutouts: Int, readArticleIDs: [ArticleID], randomArticleIDs: [ArticleID]) {
-        self.creationDate = creationDate
-        self.expirationDate = expirationDate
-        self.numBookmarkedArticles = numBookmarkedArticles
-        self.numReadArticles = numReadArticles
-        self.numShoutouts = numShoutouts
-        self.readArticleIDs = readArticleIDs
-        self.randomArticleIDs = randomArticleIDs
-    }
-    
-    static func dummyDebrief() -> WeeklyDebrief {
-        WeeklyDebrief(
-            creationDate: Date(),
-            expirationDate: Date(),
-            numBookmarkedArticles: 33,
-            numReadArticles: 22,
-            numShoutouts: 11,
-            readArticleIDs: ["618f63022fef10d6b75ec9a5", "618f63022fef10d6b75ec9a6"],
-            randomArticleIDs: ["618f63022fef10d6b75ec9ae", "618f63022fef10d6b75ec9b5"]
-        )
-    }
 }

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -152,7 +152,7 @@ class NetworkState: ObservableObject {
     func handleCompletion(screen: Screen, _ completion: Subscribers.Completion<WrappedGraphQLError>) {
         if case let .failure(error) = completion {
             networkScreenFailed[screen] = true
-            print("Error on \(screen.rawValue): \(error)")
+            print("Error on \(screen.rawValue): \(error.localizedDescription)")
         } else {
             networkScreenFailed[screen] = false
         }

--- a/Volume/Supporting/AppDelegate.swift
+++ b/Volume/Supporting/AppDelegate.swift
@@ -31,11 +31,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
         let deviceTokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        #if DEBUG
         print("UIApplicationDelegate didRegisterForRemoteNotifications with deviceToken: \(deviceTokenString)")
+        #endif
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        #if DEBUG
         print("Error: UIApplicationDelegate didFailToRegisterForRemoteNotificationsWithError: \(error.localizedDescription)")
+        #endif
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -52,20 +52,26 @@ class Notifications: NSObject, ObservableObject {
         #endif
         guard let notificationType = userInfo["notificationType"] as? String
         else {
+            #if DEBUG
             print("Error: data or notificationType not found in push notification payload")
+            #endif
             return
         }
         switch notificationType {
         case NotificationType.newArticle.rawValue:
             guard let articleID = userInfo["articleID"] as? String else {
+                #if DEBUG
                 print("Error: missing articleID in new article notification payload")
+                #endif
                 break
             }
             openArticle(id: articleID)
         case NotificationType.weeklyDebrief.rawValue:
             isWeeklyDebriefOpen = true
         default:
+            #if DEBUG
             print("Error: unknown notificationType: \(notificationType)")
+            #endif
             break
         }
     }
@@ -94,10 +100,14 @@ extension Notifications {
 extension Notifications: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
+            #if DEBUG
             print("Firebase Messaging registration token: \(fcmToken)")
+            #endif
             UserData.shared.fcmToken = fcmToken
         } else {
+            #if DEBUG
             print("Error: Firebase Messaging failed to register")
+            #endif
             UserData.shared.fcmToken = "debugSimulatorFCMToken"
         }
         

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -131,7 +131,9 @@ class UserData: ObservableObject {
 
     func set(article: Article, isSaved: Bool) {
         guard let uuid = uuid else {
+            #if DEBUG
             print("Error: received nil for UUID in set(article:isSaved)")
+            #endif
             return
         }
         

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -278,11 +278,16 @@ struct BrowserView: View {
     private func markArticleRead(id: String) {
         guard let uuid = userData.uuid else { return }
         cancellableReadMutation = Network.shared.publisher(for: ReadArticleMutation(id: id, uuid: uuid))
+            .map { $0.readArticle?.id }
             .sink { completion in
                 if case let .failure(error) = completion {
                     print("Error: ReadArticleMutation failed on BrowserView: \(error.localizedDescription)")
                 }
-            } receiveValue: { _ in }
+            } receiveValue: { id in
+                #if DEBUG
+                print("Marked article read with ID: \(id ?? "nil")")
+                #endif
+            }
     }
 
     func displayShareScreen(for article: Article) {

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -278,7 +278,7 @@ struct BrowserView: View {
     private func markArticleRead(id: String) {
         guard let uuid = userData.uuid else { return }
         cancellableReadMutation = Network.shared.publisher(for: ReadArticleMutation(id: id, uuid: uuid))
-            .map { $0.readArticle?.id }
+            .map(\.readArticle?.id)
             .sink { completion in
                 if case let .failure(error) = completion {
                     print("Error: ReadArticleMutation failed on BrowserView: \(error.localizedDescription)")

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -162,6 +162,7 @@ struct HomeList: View {
         Group {
             Header("The Big Read")
                 .padding([.top, .horizontal])
+            
             ScrollView(.horizontal, showsIndicators: false) {
                 switch sectionStates.trendingArticles {
                 case .loading:
@@ -198,13 +199,16 @@ struct HomeList: View {
                             .renderingMode(.original)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
+                        
                         HStack(alignment: .top) {
                             Text("Your\nWeekly\nDebrief")
                                 .font(.newYorkRegular(size: 18))
                                 .foregroundColor(.volume.orange)
                                 .padding(.leading)
                                 .multilineTextAlignment(.leading)
+                            
                             Spacer()
+                            
                             Image.volume.rightArrow
                                 .padding(.trailing)
                         }
@@ -257,6 +261,7 @@ struct HomeList: View {
     var otherArticlesSection: some View {
         Group {
             Header("Other Articles").padding()
+            
             switch sectionStates.otherArticles {
             case .loading:
                 ForEach(0..<5) { _ in
@@ -288,15 +293,18 @@ struct HomeList: View {
         }) {
             VStack(spacing: 20) {
                 trendingArticlesSection
+                
                 if let _ = userData.weeklyDebrief {
                     // Reserve space for weekly debrief if user has had one before
                     weeklyDebriefButton
                 }
+                
                 followedArticlesSection
                 
                 Spacer()
                 
                 otherArticlesSection
+                
                 // Invisible navigation link only opens if application is opened
                 // through deeplink with valid article
                 if let articleID = onOpenArticleUrl {
@@ -331,10 +339,11 @@ struct HomeList: View {
             isWeeklyDebriefOpen = false
         } content: {
             if let weeklyDebrief = userData.weeklyDebrief {
-                WeeklyDebriefView(openedWeeklyDebrief: $isWeeklyDebriefOpen,
-                                  urlIsOpen: $openedUrl,
-                                  articleURL: $onOpenArticleUrl,
-                                  weeklyDebrief: weeklyDebrief)
+                WeeklyDebriefView(
+                    isOpen: $isWeeklyDebriefOpen,
+                    openedURL: $openedUrl,
+                    onOpenArticleUrl: $onOpenArticleUrl,
+                    weeklyDebrief: weeklyDebrief)
             }
         }
     }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -10,11 +10,11 @@ import Combine
 import SwiftUI
 
 struct HomeList: View {
-    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
-    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
+    @State private var isWeeklyDebriefOpen = false
     @State private var openedUrl = false
     @State private var onOpenArticleUrl: String?
-    @State private var isWeeklyDebriefOpen = false
+    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
+    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
     @EnvironmentObject private var networkState: NetworkState
     @EnvironmentObject private var notifications: Notifications
     @EnvironmentObject private var userData: UserData

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -10,14 +10,14 @@ import Combine
 import SwiftUI
 
 struct HomeList: View {
-    @State private var isWeeklyDebriefOpen = false
-    @State private var openedUrl = false
-    @State private var onOpenArticleUrl: String?
-    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
-    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
     @EnvironmentObject private var networkState: NetworkState
     @EnvironmentObject private var notifications: Notifications
     @EnvironmentObject private var userData: UserData
+    @State private var isWeeklyDebriefOpen = false
+    @State private var onOpenArticleUrl: String?
+    @State private var openedUrl = false
+    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
+    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
 
     init() {
         let coloredAppearance = UINavigationBarAppearance()
@@ -138,7 +138,9 @@ struct HomeList: View {
     
     private func fetchWeeklyDebrief() {
         guard let uuid = userData.uuid else {
+            #if DEBUG
             print("Error: received nil UUID from UserData")
+            #endif
             return
         }
         
@@ -155,7 +157,9 @@ struct HomeList: View {
                     sectionStates.weeklyDebrief = .results(weeklyDebriefObject)
                     isWeeklyDebriefOpen = true
                 } else {
+                    #if DEBUG
                     print("Error: GetWeeklyDebrief failed on HomeList: field \"weeklyDebrief\" is nil.")
+                    #endif
                     sectionStates.weeklyDebrief = .results(nil)
                 }
             }
@@ -263,7 +267,8 @@ struct HomeList: View {
     
     var otherArticlesSection: some View {
         Group {
-            Header("Other Articles").padding()
+            Header("Other Articles")
+                .padding()
             
             switch sectionStates.otherArticles {
             case .loading:
@@ -346,7 +351,8 @@ struct HomeList: View {
                     isOpen: $isWeeklyDebriefOpen,
                     openedURL: $openedUrl,
                     onOpenArticleUrl: $onOpenArticleUrl,
-                    weeklyDebrief: weeklyDebrief)
+                    weeklyDebrief: weeklyDebrief
+                )
             }
         }
     }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -36,10 +36,13 @@ struct HomeList: View {
         fetchTrendingArticles(done)
         fetchFeedArticles()
         
-        if let expirationDate = userData.weeklyDebrief?.expirationDate {
-            if expirationDate < Date() {
+        if let weeklyDebrief = userData.weeklyDebrief {
+            if weeklyDebrief.expirationDate < Date() {
                 // Cached WD expired, query new one
                 fetchWeeklyDebrief()
+            } else {
+                // Cached WD still fresh, stop loading state
+                sectionStates.weeklyDebrief = .results(weeklyDebrief)
             }
         } else {
             // No existing WD, query new one

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -138,7 +138,9 @@ struct OnboardingView: View {
     
     private func createUser() {
         guard let fcmToken = userData.fcmToken else {
+            #if DEBUG
             print("Error: received nil for fcmToken from UserData")
+            #endif
             return
         }
         

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -151,6 +151,9 @@ struct OnboardingView: View {
                 }
             } receiveValue: { uuid in
                 userData.uuid = uuid
+                #if DEBUG
+                print("User successfully created with UUID: \(uuid)")
+                #endif
                 withAnimation(.spring()) {
                     isFirstLaunch = false
                 }

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -20,6 +20,7 @@ struct WeeklyDebriefView: View {
     @Binding var openedURL: Bool
     @Binding var onOpenArticleUrl: String?
     @State private var cancellableArticleQueries = [ArticleID : AnyCancellable]()
+    @State private var currentPage: Int = 0
     @State private var articleStates = [ArticleID : MainView.TabState<Article>]()
     
     let weeklyDebrief: WeeklyDebrief
@@ -113,15 +114,18 @@ struct WeeklyDebriefView: View {
     }
     
     var body: some View {
-        TabView {
+        TabView(selection: $currentPage) {
             debriefSummary
+                .tag(0)
             
-            ForEach(weeklyDebrief.readArticleIDs, id: \.self) { id in
-                makeDebriefArticleView(articleID: id, header: "Share What You Read")
+            ForEach(weeklyDebrief.readArticleIDs.indices, id: \.self) { idx in
+                makeDebriefArticleView(articleID: weeklyDebrief.readArticleIDs[idx], header: "Share What You Read")
+                    .tag(1 + idx)
             }
             
-            ForEach(weeklyDebrief.randomArticleIDs, id: \.self) { id in
-                makeDebriefArticleView(articleID: id, header: "Top Articles of the Week")
+            ForEach(weeklyDebrief.randomArticleIDs.indices, id: \.self) { idx in
+                makeDebriefArticleView(articleID: weeklyDebrief.randomArticleIDs[idx], header: "Top Articles of the Week")
+                    .tag(1 + weeklyDebrief.readArticleIDs.count + idx)
             }
             
             debriefConclusion

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -16,30 +16,15 @@ import WebKit
 
 struct WeeklyDebriefView: View {
     @EnvironmentObject private var userData: UserData
-    
-    let weeklyDebrief: WeeklyDebrief
-    
-    @Binding private var isOpen: Bool
-    
-    @Binding private var openedURL: Bool
-    @Binding private var onOpenArticleUrl: String?
-    
-    let initType: WeeklyDebriefViewInitType
-    
+    @Binding var isOpen: Bool
+    @Binding var openedURL: Bool
+    @Binding var onOpenArticleUrl: String?
     @State private var cancellableArticleQuery: AnyCancellable?
     @State private var cancellableReadMutation: AnyCancellable?
     @State private var cancellableShoutoutMutation: AnyCancellable?
     @State private var state: MainView.TabState<WeeklyDebriefDisplayInfo> = .loading
     
-    init(openedWeeklyDebrief: Binding<Bool>, urlIsOpen: Binding<Bool>, articleURL: Binding<String?>, weeklyDebrief: WeeklyDebrief) {
-        _isOpen = openedWeeklyDebrief
-        self.weeklyDebrief = weeklyDebrief
-        
-        self.initType = .fetchRequired
-        
-        _openedURL = urlIsOpen
-        _onOpenArticleUrl = articleURL
-    }
+    let weeklyDebrief: WeeklyDebrief
     
     func makeView(debriefDisplayInfo: WeeklyDebriefDisplayInfo) -> some View {
         VStack {
@@ -47,6 +32,7 @@ struct WeeklyDebriefView: View {
                 .fill(Color.secondary)
                 .frame(width: 64, height: 3)
                 .padding(10)
+            
             TabView {
                 VStack {
                     Image.volume.logo
@@ -56,18 +42,23 @@ struct WeeklyDebriefView: View {
                     Text(getWeekString())
                         .padding(.vertical, 32)
                         .font(.newYorkMedium(size: 16))
+                    
                     Divider()
                         .frame(width: 100)
                         .padding(.bottom, 48)
+                    
                     VStack(spacing: 24) {
                         HStack {
                             Text("In the past week, you...")
                                 .font(.newYorkRegular(size: 16))
+                            
                             Spacer()
                         }
+                        
                         StatisticView(image: .volume.feed, leftText: "read", number: debriefDisplayInfo.numReadArticles, rightText: "articles")
                         StatisticView(image: .volume.shoutout, leftText: "gave", number: debriefDisplayInfo.numShoutouts, rightText: "shout-outs")
                         StatisticView(image: .volume.bookmark, leftText: "bookmarked", number: debriefDisplayInfo.numBookmarkedArticles, rightText: "articles")
+                        
                         HStack {
                             Text("You were among the top ")
                                 .font(.newYorkRegular(size: 16)) +
@@ -76,18 +67,23 @@ struct WeeklyDebriefView: View {
                                 .foregroundColor(.volume.orange) +
                             Text("active readers last week!")
                                 .font(.newYorkRegular(size: 16))
+                            
                             Spacer()
                         }
+                        
                         HStack {
                             Text("Keep up the volume! 📣")
                                 .font(.newYorkRegular(size: 16))
                                 .frame(alignment: .leading)
+                            
                             Spacer()
                         }
                     }
                     .padding(.horizontal, 48)
+                    
                     Spacer()
                 }
+                
                 ForEach(debriefDisplayInfo.readArticles) { article in
                     DebriefArticleView(header: "Share What You Read",
                                        article: article,
@@ -95,6 +91,7 @@ struct WeeklyDebriefView: View {
                                        isURLOpen: $openedURL,
                                        articleID: $onOpenArticleUrl)
                 }
+                
                 ForEach(debriefDisplayInfo.randomArticles) { article in
                     DebriefArticleView(header: "Top Articles of the Week",
                                        article: article,
@@ -102,9 +99,11 @@ struct WeeklyDebriefView: View {
                                        isURLOpen: $openedURL,
                                        articleID: $onOpenArticleUrl)
                 }
+                
                 VStack {
                     Header("See You Next Week!", .center)
                         .padding(.top, 24)
+                    
                     VStack {
                         Image.volume.logo
                             .resizable()
@@ -113,6 +112,7 @@ struct WeeklyDebriefView: View {
                             .font(.newYorkRegular(size: 16))
                     }
                     .padding(.top, 200)
+                    
                     Button {
                         isOpen = false
                     } label: {
@@ -179,7 +179,6 @@ struct WeeklyDebriefView: View {
     }
     
     private func fetchInfoFor(debrief: WeeklyDebrief) {
-        
         let startingDisplayInfo = WeeklyDebriefDisplayInfo(
             creationDate: debrief.creationDate,
             expirationDate: debrief.expirationDate,
@@ -200,26 +199,11 @@ struct WeeklyDebriefView: View {
      * Creates a date string for the past week
      */
     private func getWeekString() -> String {
-        var message = "Your weekly debrief"
-        
-        let firstDay = weeklyDebrief.creationDate.simpleString
-        let lastDay = weeklyDebrief.expirationDate.simpleString
-        
-        message.append(contentsOf: ", \(firstDay) - \(lastDay)")
-        
-        return message
+        return "Your weekly debrief, \(weeklyDebrief.creationDate.simpleString) - \(weeklyDebrief.expirationDate.simpleString)"
     }
 }
 
 extension WeeklyDebriefView {
-    private enum WeeklyDebriefViewState<Result> {
-        case loading, results(Result)
-    }
-    
-    enum WeeklyDebriefViewInitType {
-        case readyForDisplay(WeeklyDebrief), fetchRequired
-    }
-    
     struct WeeklyDebriefDisplayInfo {
         var creationDate: Date
         var expirationDate: Date

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -129,6 +129,7 @@ struct WeeklyDebriefView: View {
             }
             
             debriefConclusion
+                .tag(1 + weeklyDebrief.readArticleIDs.count + weeklyDebrief.randomArticleIDs.count)
         }
         .tabViewStyle(PageTabViewStyle())
         .onAppear {


### PR DESCRIPTION
## Overview

Fix networking & data representation for Weekly Debrief. Concurrently load articles upon opening popup. 

## Changes Made

- Fix style nits that made it past review
- Remove loading state for `WeeklyDebriefView`'s first page, since `weeklyDebrief` is already cached when `WeeklyDebriefView` pops up.
- Add loading states for WD article pages, since we need to request the WD's two `articleIDs` arrays
- Remove explicit `init` functions
- Remove unused types: `WeeklyDebriefDisplayInfo`, `WeeklyDebriefState`, `WeeklyDebriefInitType`
- Fix error message format in `NetworkState`
- Add debug logging for WD-related mutations
- Fix loading state for cached WD

## Test Coverage

- iPhone 13 Pro (Simulator)

## Next Steps

- Fix Networking issue with WeeklyDebrief as well as the last TabView on WeeklyDebrief (related: https://github.com/cuappdev/volume-ios/pull/100)

## Screenshots

Before, if a valid WD was cached, `weeklyDebriefButton` would never change from `.loading` to `.results`.

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><video width="564" alt="Screenshot 2022-04-21 at 3 51 47 PM" src="https://user-images.githubusercontent.com/13712511/164547841-9a9231c1-575d-4453-b4c1-17594ff4afea.mp4"></td>
    <td>
<video width="564" alt="Screenshot 2022-04-21 at 3 52 18 PM" src="https://user-images.githubusercontent.com/13712511/164547843-99d6dc92-bc7c-478b-b839-18035755181d.mp4">
</td>
  </tr>
</table>

