### PR TITLE
Implement Weekly Debrief SkeletonView

### DIFF
--- a/Volume/Models/WeeklyDebrief.swift
+++ b/Volume/Models/WeeklyDebrief.swift
@@ -26,26 +26,4 @@ struct WeeklyDebrief: Codable {
         readArticleIDs = weeklyDebrief.readArticles.map(\.fragments.articleFields.id)
         randomArticleIDs = weeklyDebrief.randomArticles.map(\.fragments.articleFields.id)
     }
-    
-    init(creationDate: Date, expirationDate: Date, numBookmarkedArticles: Int, numReadArticles: Int, numShoutouts: Int, readArticleIDs: [ArticleID], randomArticleIDs: [ArticleID]) {
-        self.creationDate = creationDate
-        self.expirationDate = expirationDate
-        self.numBookmarkedArticles = numBookmarkedArticles
-        self.numReadArticles = numReadArticles
-        self.numShoutouts = numShoutouts
-        self.readArticleIDs = readArticleIDs
-        self.randomArticleIDs = randomArticleIDs
-    }
-    
-    static func dummyDebrief() -> WeeklyDebrief {
-        WeeklyDebrief(
-            creationDate: Date(),
-            expirationDate: Date(),
-            numBookmarkedArticles: 33,
-            numReadArticles: 22,
-            numShoutouts: 11,
-            readArticleIDs: ["618f63022fef10d6b75ec9a5", "618f63022fef10d6b75ec9a6"],
-            randomArticleIDs: ["618f63022fef10d6b75ec9ae", "618f63022fef10d6b75ec9b5"]
-        )
-    }
 }

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -152,7 +152,7 @@ class NetworkState: ObservableObject {
     func handleCompletion(screen: Screen, _ completion: Subscribers.Completion<WrappedGraphQLError>) {
         if case let .failure(error) = completion {
             networkScreenFailed[screen] = true
-            print("Error on \(screen.rawValue): \(error)")
+            print("Error on \(screen.rawValue): \(error.localizedDescription)")
         } else {
             networkScreenFailed[screen] = false
         }

--- a/Volume/View Models/ArticleInfo.swift
+++ b/Volume/View Models/ArticleInfo.swift
@@ -55,9 +55,11 @@ struct ArticleInfo: View {
 extension ArticleInfo {
     struct Skeleton: View {
         let showsPublicationName: Bool
+        let isDebrief: Bool
 
-        init(showsPublicationName: Bool = true) {
+        init(showsPublicationName: Bool = true, isDebrief: Bool = false) {
             self.showsPublicationName = showsPublicationName
+            self.isDebrief = isDebrief
         }
 
         var body: some View {
@@ -65,20 +67,23 @@ extension ArticleInfo {
                 VStack(alignment: .leading, spacing: 0) {
                     if showsPublicationName {
                         SkeletonView()
-                            .frame(width: 70, height: 14)
-                            .padding(.bottom, 3)
+                            .frame(width: 70, height: isDebrief ? 23 : 14)
+                            .padding(.bottom, isDebrief ? 4 : 3)
                     }
+
                     SkeletonView()
-                        .frame(height: 40)
+                        .frame(height: isDebrief ? 90 : 40)
+
                     Spacer()
-                    HStack(spacing: 0) {
+
+                    HStack(alignment: .firstTextBaseline) {
                         SkeletonView()
-                            .frame(width: 33, height: 10)
+                            .frame(width: 33, height: isDebrief ? 14 : 10)
                         Text(" • ")
                             .font(.helveticaRegular(size: 10))
                             .foregroundColor(.volume.veryLightGray)
                         SkeletonView()
-                            .frame(width: 70, height: 10)
+                            .frame(width: 70, height: isDebrief ? 14 : 10)
                     }
                 }
                 Spacer()

--- a/Volume/Views/BrowserView.swift
+++ b/Volume/Views/BrowserView.swift
@@ -278,11 +278,16 @@ struct BrowserView: View {
     private func markArticleRead(id: String) {
         guard let uuid = userData.uuid else { return }
         cancellableReadMutation = Network.shared.publisher(for: ReadArticleMutation(id: id, uuid: uuid))
+            .map { $0.readArticle?.id }
             .sink { completion in
                 if case let .failure(error) = completion {
                     print("Error: ReadArticleMutation failed on BrowserView: \(error.localizedDescription)")
                 }
-            } receiveValue: { _ in }
+            } receiveValue: { id in
+                #if DEBUG
+                print("Marked article read with ID: \(id ?? "nil")")
+                #endif
+            }
     }
 
     func displayShareScreen(for article: Article) {

--- a/Volume/Views/DebriefArticleView.swift
+++ b/Volume/Views/DebriefArticleView.swift
@@ -11,6 +11,13 @@ import Combine
 import SDWebImageSwiftUI
 import SwiftUI
 
+let buttonSize: CGFloat = 44
+let buttonLabelHeight: CGFloat = 21
+let buttonSpacing: CGFloat = 56
+let bodySpacing: CGFloat = 30
+let bodyFrameSize: CGFloat = 275
+let bodyFrameHeight: CGFloat = 435
+
 struct DebriefArticleView: View {
     @State private var cancellableShoutoutMutation: AnyCancellable?
     @EnvironmentObject private var userData: UserData
@@ -20,13 +27,6 @@ struct DebriefArticleView: View {
     @Binding private var isDebriefOpen: Bool
     @Binding private var isURLOpen: Bool
     @Binding private var articleID: String?
-    
-    let buttonSize: CGFloat = 44
-    let buttonLabelHeight: CGFloat = 21
-    let buttonSpacing: CGFloat = 56
-    let bodySpacing: CGFloat = 30
-    let bodyFrameSize: CGFloat = 275
-    let bodyFrameHeight: CGFloat = 435
     
     init(header: String, article: Article, isDebriefOpen: Binding<Bool>, isURLOpen: Binding<Bool>, articleID: Binding<String?>) {
         self.header = header
@@ -89,9 +89,10 @@ struct DebriefArticleView: View {
     }
     
     var body: some View {
-        VStack(spacing: bodySpacing) {
+        VStack(spacing: 0) {
             Header(header, .center)
                 .padding(.top, 24)
+                .padding(.bottom, 30)
             
             NavigationLink(destination: BrowserView(initType: .readyForDisplay(article), navigationSource: .weeklyDebrief)) {
                 VStack(spacing: 16) {
@@ -119,6 +120,8 @@ struct DebriefArticleView: View {
             }
             .frame(width: bodyFrameSize, height: bodyFrameHeight)
             .accentColor(.black)
+
+            Spacer()
             
             HStack(spacing: buttonSpacing) {
                 saveButton
@@ -126,8 +129,7 @@ struct DebriefArticleView: View {
                 shoutoutButton
             }
             .padding(.horizontal, 65)
-            .padding(.top, bodySpacing)
-            Spacer()
+            .padding(.bottom, 100)
         }
     }
 
@@ -156,6 +158,42 @@ struct DebriefArticleView: View {
                     print("Error: IncrementShoutoutsMutation failed on DebriefArticleView: \(error.localizedDescription)")
                 }
             }, receiveValue: { _ in })
+    }
+}
+
+extension DebriefArticleView {
+    struct Skeleton: View {
+        var body: some View {
+            VStack(spacing: 0) {
+                // Header
+                SkeletonView()
+                    .frame(width: 217, height: 42)
+                    .padding(.top, 24)
+                    .padding(.bottom, 30)
+
+                VStack(spacing: 16) {
+                    // Image
+                    SkeletonView()
+                        .frame(width: bodyFrameSize, height: bodyFrameSize)
+
+                    // ArticleInfo
+                    ArticleInfo
+                        .Skeleton(showsPublicationName: true, isDebrief: true)
+                }
+                .frame(width: bodyFrameSize, height: bodyFrameHeight)
+
+                Spacer()
+
+                // Buttons
+                HStack(spacing: buttonSpacing) {
+                    SkeletonView().frame(width: buttonSize, height: buttonSize)
+                    SkeletonView().frame(width: buttonSize, height: buttonSize)
+                    SkeletonView().frame(width: buttonSize, height: buttonSize)
+                }
+                .padding(.horizontal, 65)
+                .padding(.bottom, 100)
+            }
+        }
     }
 }
 

--- a/Volume/Views/DebriefArticleView.swift
+++ b/Volume/Views/DebriefArticleView.swift
@@ -170,25 +170,30 @@ extension DebriefArticleView {
                     .frame(width: 217, height: 42)
                     .padding(.top, 24)
                     .padding(.bottom, 30)
+                    .cornerRadius(5)
 
                 VStack(spacing: 16) {
                     // Image
                     SkeletonView()
                         .frame(width: bodyFrameSize, height: bodyFrameSize)
+                        .cornerRadius(5)
 
                     // ArticleInfo
                     ArticleInfo
                         .Skeleton(showsPublicationName: true, isDebrief: true)
                 }
                 .frame(width: bodyFrameSize, height: bodyFrameHeight)
+                .cornerRadius(5)
 
                 Spacer()
 
                 // Buttons
                 HStack(spacing: buttonSpacing) {
-                    SkeletonView().frame(width: buttonSize, height: buttonSize)
-                    SkeletonView().frame(width: buttonSize, height: buttonSize)
-                    SkeletonView().frame(width: buttonSize, height: buttonSize)
+                    ForEach((1...3), id: \.self) {_ in
+                        SkeletonView()
+                            .frame(width: buttonSize, height: buttonSize)
+                            .cornerRadius(buttonSize / 2)
+                    }
                 }
                 .padding(.horizontal, 65)
                 .padding(.bottom, 100)

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -162,6 +162,7 @@ struct HomeList: View {
         Group {
             Header("The Big Read")
                 .padding([.top, .horizontal])
+            
             ScrollView(.horizontal, showsIndicators: false) {
                 switch sectionStates.trendingArticles {
                 case .loading:
@@ -198,13 +199,16 @@ struct HomeList: View {
                             .renderingMode(.original)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
+                        
                         HStack(alignment: .top) {
                             Text("Your\nWeekly\nDebrief")
                                 .font(.newYorkRegular(size: 18))
                                 .foregroundColor(.volume.orange)
                                 .padding(.leading)
                                 .multilineTextAlignment(.leading)
+                            
                             Spacer()
+                            
                             Image.volume.rightArrow
                                 .padding(.trailing)
                         }
@@ -257,6 +261,7 @@ struct HomeList: View {
     var otherArticlesSection: some View {
         Group {
             Header("Other Articles").padding()
+            
             switch sectionStates.otherArticles {
             case .loading:
                 ForEach(0..<5) { _ in
@@ -288,15 +293,18 @@ struct HomeList: View {
         }) {
             VStack(spacing: 20) {
                 trendingArticlesSection
+                
                 if let _ = userData.weeklyDebrief {
                     // Reserve space for weekly debrief if user has had one before
                     weeklyDebriefButton
                 }
+                
                 followedArticlesSection
                 
                 Spacer()
                 
                 otherArticlesSection
+                
                 // Invisible navigation link only opens if application is opened
                 // through deeplink with valid article
                 if let articleID = onOpenArticleUrl {
@@ -331,10 +339,11 @@ struct HomeList: View {
             isWeeklyDebriefOpen = false
         } content: {
             if let weeklyDebrief = userData.weeklyDebrief {
-                WeeklyDebriefView(openedWeeklyDebrief: $isWeeklyDebriefOpen,
-                                  urlIsOpen: $openedUrl,
-                                  articleURL: $onOpenArticleUrl,
-                                  weeklyDebrief: weeklyDebrief)
+                WeeklyDebriefView(
+                    isOpen: $isWeeklyDebriefOpen,
+                    openedURL: $openedUrl,
+                    onOpenArticleUrl: $onOpenArticleUrl,
+                    weeklyDebrief: weeklyDebrief)
             }
         }
     }

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -10,11 +10,11 @@ import Combine
 import SwiftUI
 
 struct HomeList: View {
-    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
-    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
+    @State private var isWeeklyDebriefOpen = false
     @State private var openedUrl = false
     @State private var onOpenArticleUrl: String?
-    @State private var isWeeklyDebriefOpen = false
+    @State private var sectionStates: SectionStates = (.loading, .loading, .loading, .loading)
+    @State private var sectionQueries: SectionQueries = (nil, nil, nil)
     @EnvironmentObject private var networkState: NetworkState
     @EnvironmentObject private var notifications: Notifications
     @EnvironmentObject private var userData: UserData

--- a/Volume/Views/MainView/HomeList.swift
+++ b/Volume/Views/MainView/HomeList.swift
@@ -36,10 +36,13 @@ struct HomeList: View {
         fetchTrendingArticles(done)
         fetchFeedArticles()
         
-        if let expirationDate = userData.weeklyDebrief?.expirationDate {
-            if expirationDate < Date() {
+        if let weeklyDebrief = userData.weeklyDebrief {
+            if weeklyDebrief.expirationDate < Date() {
                 // Cached WD expired, query new one
                 fetchWeeklyDebrief()
+            } else {
+                // Cached WD still fresh, stop loading state
+                sectionStates.weeklyDebrief = .results(weeklyDebrief)
             }
         } else {
             // No existing WD, query new one

--- a/Volume/Views/Onboarding/OnboardingView.swift
+++ b/Volume/Views/Onboarding/OnboardingView.swift
@@ -151,6 +151,9 @@ struct OnboardingView: View {
                 }
             } receiveValue: { uuid in
                 userData.uuid = uuid
+                #if DEBUG
+                print("User successfully created with UUID: \(uuid)")
+                #endif
                 withAnimation(.spring()) {
                     isFirstLaunch = false
                 }

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -20,6 +20,7 @@ struct WeeklyDebriefView: View {
     @Binding var openedURL: Bool
     @Binding var onOpenArticleUrl: String?
     @State private var cancellableArticleQueries = [ArticleID : AnyCancellable]()
+    @State private var currentPage: Int = 0
     @State private var articleStates = [ArticleID : MainView.TabState<Article>]()
     
     let weeklyDebrief: WeeklyDebrief
@@ -113,15 +114,18 @@ struct WeeklyDebriefView: View {
     }
     
     var body: some View {
-        TabView {
+        TabView(selection: $currentPage) {
             debriefSummary
+                .tag(0)
             
-            ForEach(weeklyDebrief.readArticleIDs, id: \.self) { id in
-                makeDebriefArticleView(articleID: id, header: "Share What You Read")
+            ForEach(weeklyDebrief.readArticleIDs.indices, id: \.self) { idx in
+                makeDebriefArticleView(articleID: weeklyDebrief.readArticleIDs[idx], header: "Share What You Read")
+                    .tag(1 + idx)
             }
             
-            ForEach(weeklyDebrief.randomArticleIDs, id: \.self) { id in
-                makeDebriefArticleView(articleID: id, header: "Top Articles of the Week")
+            ForEach(weeklyDebrief.randomArticleIDs.indices, id: \.self) { idx in
+                makeDebriefArticleView(articleID: weeklyDebrief.randomArticleIDs[idx], header: "Top Articles of the Week")
+                    .tag(1 + weeklyDebrief.readArticleIDs.count + idx)
             }
             
             debriefConclusion

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -82,14 +82,17 @@ struct WeeklyDebriefView: View {
             Header("See You Next Week!", .center)
                 .padding(.top, 24)
             
-            VStack {
+            VStack(spacing: 16) {
                 Image.volume.logo
                     .resizable()
                     .frame(width: 245, height: 75)
                 Text("Stay updated with Cornell student publications, all in one place")
                     .font(.newYorkRegular(size: 16))
+                    .multilineTextAlignment(.center)
             }
             .padding(.top, 200)
+
+            Spacer()
             
             Button {
                 isOpen = false
@@ -98,6 +101,12 @@ struct WeeklyDebriefView: View {
                     .foregroundColor(.volume.orange)
                     .font(.helveticaBold(size: 16))
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .overlay(RoundedRectangle(cornerRadius: 26)
+                .stroke(Color.volume.orange, lineWidth: 2))
+
+            Spacer().frame(height: 100)
         }
         .padding(.horizontal, 50)
     }

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -16,30 +16,15 @@ import WebKit
 
 struct WeeklyDebriefView: View {
     @EnvironmentObject private var userData: UserData
-    
-    let weeklyDebrief: WeeklyDebrief
-    
-    @Binding private var isOpen: Bool
-    
-    @Binding private var openedURL: Bool
-    @Binding private var onOpenArticleUrl: String?
-    
-    let initType: WeeklyDebriefViewInitType
-    
+    @Binding var isOpen: Bool
+    @Binding var openedURL: Bool
+    @Binding var onOpenArticleUrl: String?
     @State private var cancellableArticleQuery: AnyCancellable?
     @State private var cancellableReadMutation: AnyCancellable?
     @State private var cancellableShoutoutMutation: AnyCancellable?
     @State private var state: MainView.TabState<WeeklyDebriefDisplayInfo> = .loading
     
-    init(openedWeeklyDebrief: Binding<Bool>, urlIsOpen: Binding<Bool>, articleURL: Binding<String?>, weeklyDebrief: WeeklyDebrief) {
-        _isOpen = openedWeeklyDebrief
-        self.weeklyDebrief = weeklyDebrief
-        
-        self.initType = .fetchRequired
-        
-        _openedURL = urlIsOpen
-        _onOpenArticleUrl = articleURL
-    }
+    let weeklyDebrief: WeeklyDebrief
     
     func makeView(debriefDisplayInfo: WeeklyDebriefDisplayInfo) -> some View {
         VStack {
@@ -47,6 +32,7 @@ struct WeeklyDebriefView: View {
                 .fill(Color.secondary)
                 .frame(width: 64, height: 3)
                 .padding(10)
+            
             TabView {
                 VStack {
                     Image.volume.logo
@@ -56,18 +42,23 @@ struct WeeklyDebriefView: View {
                     Text(getWeekString())
                         .padding(.vertical, 32)
                         .font(.newYorkMedium(size: 16))
+                    
                     Divider()
                         .frame(width: 100)
                         .padding(.bottom, 48)
+                    
                     VStack(spacing: 24) {
                         HStack {
                             Text("In the past week, you...")
                                 .font(.newYorkRegular(size: 16))
+                            
                             Spacer()
                         }
+                        
                         StatisticView(image: .volume.feed, leftText: "read", number: debriefDisplayInfo.numReadArticles, rightText: "articles")
                         StatisticView(image: .volume.shoutout, leftText: "gave", number: debriefDisplayInfo.numShoutouts, rightText: "shout-outs")
                         StatisticView(image: .volume.bookmark, leftText: "bookmarked", number: debriefDisplayInfo.numBookmarkedArticles, rightText: "articles")
+                        
                         HStack {
                             Text("You were among the top ")
                                 .font(.newYorkRegular(size: 16)) +
@@ -76,18 +67,23 @@ struct WeeklyDebriefView: View {
                                 .foregroundColor(.volume.orange) +
                             Text("active readers last week!")
                                 .font(.newYorkRegular(size: 16))
+                            
                             Spacer()
                         }
+                        
                         HStack {
                             Text("Keep up the volume! 📣")
                                 .font(.newYorkRegular(size: 16))
                                 .frame(alignment: .leading)
+                            
                             Spacer()
                         }
                     }
                     .padding(.horizontal, 48)
+                    
                     Spacer()
                 }
+                
                 ForEach(debriefDisplayInfo.readArticles) { article in
                     DebriefArticleView(header: "Share What You Read",
                                        article: article,
@@ -95,6 +91,7 @@ struct WeeklyDebriefView: View {
                                        isURLOpen: $openedURL,
                                        articleID: $onOpenArticleUrl)
                 }
+                
                 ForEach(debriefDisplayInfo.randomArticles) { article in
                     DebriefArticleView(header: "Top Articles of the Week",
                                        article: article,
@@ -102,9 +99,11 @@ struct WeeklyDebriefView: View {
                                        isURLOpen: $openedURL,
                                        articleID: $onOpenArticleUrl)
                 }
+                
                 VStack {
                     Header("See You Next Week!", .center)
                         .padding(.top, 24)
+                    
                     VStack {
                         Image.volume.logo
                             .resizable()
@@ -113,6 +112,7 @@ struct WeeklyDebriefView: View {
                             .font(.newYorkRegular(size: 16))
                     }
                     .padding(.top, 200)
+                    
                     Button {
                         isOpen = false
                     } label: {
@@ -179,7 +179,6 @@ struct WeeklyDebriefView: View {
     }
     
     private func fetchInfoFor(debrief: WeeklyDebrief) {
-        
         let startingDisplayInfo = WeeklyDebriefDisplayInfo(
             creationDate: debrief.creationDate,
             expirationDate: debrief.expirationDate,
@@ -200,26 +199,11 @@ struct WeeklyDebriefView: View {
      * Creates a date string for the past week
      */
     private func getWeekString() -> String {
-        var message = "Your weekly debrief"
-        
-        let firstDay = weeklyDebrief.creationDate.simpleString
-        let lastDay = weeklyDebrief.expirationDate.simpleString
-        
-        message.append(contentsOf: ", \(firstDay) - \(lastDay)")
-        
-        return message
+        return "Your weekly debrief, \(weeklyDebrief.creationDate.simpleString) - \(weeklyDebrief.expirationDate.simpleString)"
     }
 }
 
 extension WeeklyDebriefView {
-    private enum WeeklyDebriefViewState<Result> {
-        case loading, results(Result)
-    }
-    
-    enum WeeklyDebriefViewInitType {
-        case readyForDisplay(WeeklyDebrief), fetchRequired
-    }
-    
     struct WeeklyDebriefDisplayInfo {
         var creationDate: Date
         var expirationDate: Date

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -115,7 +115,7 @@ struct WeeklyDebriefView: View {
         Group {
             switch articleStates[articleID] {
             case .loading, .none:
-                BigReadArticleRow.Skeleton() // TODO: create DebriefArticleView.Skeleton
+                DebriefArticleView.Skeleton()
             case .reloading(let article), .results(let article):
                 DebriefArticleView(header: header, article: article, isDebriefOpen: $isOpen, isURLOpen: $openedURL, articleID: $onOpenArticleUrl)
             }

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -129,6 +129,7 @@ struct WeeklyDebriefView: View {
             }
             
             debriefConclusion
+                .tag(1 + weeklyDebrief.readArticleIDs.count + weeklyDebrief.randomArticleIDs.count)
         }
         .tabViewStyle(PageTabViewStyle())
         .onAppear {


### PR DESCRIPTION
## Overview

Implemented the SkeletonView for weekly debrief.



## Changes Made

- Implement DebriefView skeleton
- Refactor DebriefView UI to fit design more accurately



## Test Coverage

- iPhone XR
- iPhone 13 (Simulator)


## Related PRs or Issues (delete if not applicable)

- Merge #101 first
- Merge #102 next
- Then merge this PR


## Screenshots (delete if not applicable)

<table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>


  <tr>
    <td>
<img alt="old debrief skeleton" src="https://user-images.githubusercontent.com/57964367/164762022-098df278-a97b-4d4b-8363-e1e5d01320eb.png">
    </td>
    <td>
<img  alt="new debrief skeleton" src="https://user-images.githubusercontent.com/57964367/164762009-d4588293-9d99-46ee-a67f-85f84734ed09.png">
    </td>
  </tr>

  <tr>
    <td>
<img alt="old tab view" src="https://user-images.githubusercontent.com/57964367/164762035-64f55f05-e3fc-4c4c-ba49-22049b516205.png">
    </td>
    <td>
<img alt="new-tabview" src="https://user-images.githubusercontent.com/57964367/164762043-09fc8480-4c8d-4252-b17d-0432a47e2ac7.png">
    </td>
  </tr>

  <tr>
    <td>
<video src="https://user-images.githubusercontent.com/57964367/164762061-f71274d6-0f6a-44db-a837-b53d31ea8926.mp4">
    </td>
    <td>
<video src="https://user-images.githubusercontent.com/57964367/164762070-215856ae-ffec-46ba-b560-b042ae0f6c2a.mp4">
    </td>
  </tr>

</table>

