### PR TITLE
Update CocoaPods for project

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,12 +6,11 @@ target 'Volume' do
   use_frameworks!
 
   # Pods for Volume
-  pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
   pod 'Apollo'
+  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/analytics-ios.git', :commit => '5d459c0475'
+  pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
+  pod 'Firebase/Messaging'
   pod 'SDWebImageSwiftUI'
   pod 'SDWebImageSVGCoder'
-  pod 'SwiftUIRefresh'
-  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/analytics-ios.git', :commit => '5d459c0475'
-  pod 'Firebase/Messaging'
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Apollo (0.49.1):
-    - Apollo/Core (= 0.49.1)
-  - Apollo/Core (0.49.1)
+  - Apollo (0.53.0):
+    - Apollo/Core (= 0.53.0)
+  - Apollo/Core (0.53.0)
   - AppDevAnalytics (0.2.0):
     - Firebase/Analytics (~> 7.7.0)
   - AppDevAnnouncements (0.0.1)
@@ -60,41 +60,38 @@ PODS:
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30907.0)
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.5.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.8.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.5.0):
+  - GoogleUtilities/Environment (7.8.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.5.0):
+  - GoogleUtilities/Logger (7.8.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.5.0):
+  - GoogleUtilities/MethodSwizzler (7.8.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.5.0):
+  - GoogleUtilities/Network (7.8.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.5.0)"
-  - GoogleUtilities/Reachability (7.5.0):
+  - "GoogleUtilities/NSData+zlib (7.8.0)"
+  - GoogleUtilities/Reachability (7.8.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.5.0):
+  - GoogleUtilities/UserDefaults (7.8.0):
     - GoogleUtilities/Logger
-  - Introspect (0.1.3)
   - nanopb (2.30907.0):
     - nanopb/decode (= 2.30907.0)
     - nanopb/encode (= 2.30907.0)
   - nanopb/decode (2.30907.0)
   - nanopb/encode (2.30907.0)
   - PromisesObjC (1.2.12)
-  - SDWebImage (5.11.1):
-    - SDWebImage/Core (= 5.11.1)
-  - SDWebImage/Core (5.11.1)
+  - SDWebImage (5.13.3):
+    - SDWebImage/Core (= 5.13.3)
+  - SDWebImage/Core (5.13.3)
   - SDWebImageSVGCoder (1.6.1):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageSwiftUI (2.0.2):
+  - SDWebImageSwiftUI (2.1.0):
     - SDWebImage (~> 5.10)
-  - SwiftUIRefresh (0.0.3):
-    - Introspect (~> 0.1.0)
 
 DEPENDENCIES:
   - Apollo
@@ -103,7 +100,6 @@ DEPENDENCIES:
   - Firebase/Messaging
   - SDWebImageSVGCoder
   - SDWebImageSwiftUI
-  - SwiftUIRefresh
 
 SPEC REPOS:
   trunk:
@@ -118,13 +114,11 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
-    - Introspect
     - nanopb
     - PromisesObjC
     - SDWebImage
     - SDWebImageSVGCoder
     - SDWebImageSwiftUI
-    - SwiftUIRefresh
 
 EXTERNAL SOURCES:
   AppDevAnalytics:
@@ -142,7 +136,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/cuappdev/appdev-announcements.git
 
 SPEC CHECKSUMS:
-  Apollo: 69f35ed8f8d87c32ef89e99e4f8c682399e9192b
+  Apollo: 204819ea82022fbc59ad05056820df867f19bd02
   AppDevAnalytics: 994c1ca730d79fbe530ce06b7bbffd5d05deff80
   AppDevAnnouncements: e17a7f441fb0664583bb08e21dc709214d15b70f
   Firebase: cd2ab85eec8170dc260186159f21072ecb679ad5
@@ -154,15 +148,13 @@ SPEC CHECKSUMS:
   FirebaseMessaging: ce33c2537fdda1d1a4bc82b2245e3c3bf9107684
   GoogleAppMeasurement: 0c3b134b2c0a90c4c24833873894bfe0e42a0384
   GoogleDataTransport: 8b0e733ea77c9218778e5a9e34ba9508b8328939
-  GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
-  Introspect: 2be020f30f084ada52bb4387fff83fa52c5c400e
+  GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
   nanopb: 59221d7f958fb711001e6a449489542d92ae113e
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImage: af5bbffef2cde09f148d826f9733dcde1a9414cd
   SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
-  SDWebImageSwiftUI: 8a3923c95108312b03a599ec1498754af55a6819
-  SwiftUIRefresh: ca6ae2718d25aad5dd68bbf5d2ae36ef6ade98bf
+  SDWebImageSwiftUI: 76c824afd24d896710e47f240755a31b80e056a0
 
-PODFILE CHECKSUM: c0cfaa68eab758db43a05ebddeeaf9853d7e439f
+PODFILE CHECKSUM: 1f26e9c25bee7cc3a620ee2eaa6eea2d7d4e56ad
 
 COCOAPODS: 1.11.2

--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		502E3EA32757D3C6005DA441 /* WeeklyDebriefView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E3EA22757D3C6005DA441 /* WeeklyDebriefView.swift */; };
 		502E3EA52757F774005DA441 /* StatisticView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502E3EA42757F774005DA441 /* StatisticView.swift */; };
 		50C360542759482A006CDB2E /* DebriefArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C360532759482A006CDB2E /* DebriefArticleView.swift */; };
-		54E326C736B9BE60F5002B5D /* Pods_Volume.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDD49BC6A6691BB636B1EBD1 /* Pods_Volume.framework */; };
 		7E23DFD2254A05EF0001C3A3 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E23DFD1254A05EF0001C3A3 /* Color+Extension.swift */; };
 		7E369E1725EED97500FC0419 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7E369E1625EED97500FC0419 /* Secrets.plist */; };
 		7E416C2F2561D47C0010D70B /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E416C2E2561D47C0010D70B /* Date+Extension.swift */; };
@@ -69,6 +68,7 @@
 		95F1DC8A2608F4DD000B3D91 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 95F1DC892608F4DD000B3D91 /* GoogleService-Info.plist */; };
 		990081EF25E5C31600BF8362 /* Events.md in Resources */ = {isa = PBXBuildFile; fileRef = 990081EE25E5C31600BF8362 /* Events.md */; };
 		995C9A0025E5770D00F6FBA5 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995C99FF25E5770D00F6FBA5 /* Analytics.swift */; };
+		9F35EE5AB6332722632EAF82 /* Pods_Volume.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA62FF4EAFC9DE4F9A2FFE3B /* Pods_Volume.framework */; };
 		A2532AF127B5A34500A88B82 /* schema.json in Resources */ = {isa = PBXBuildFile; fileRef = A2532AF027B5A34500A88B82 /* schema.json */; };
 		A2532AF327B5A37200A88B82 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2532AF227B5A37200A88B82 /* API.swift */; };
 		A2A4CB1C27D5276D00774C70 /* Magazine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A4CB1B27D5276D00774C70 /* Magazine.swift */; };
@@ -97,6 +97,7 @@
 		06B80D12257DC18600F3BF9B /* WebImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebImage+Extension.swift"; sourceTree = "<group>"; };
 		06DBC683257DE35F00B6A453 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationDetailHeader.swift; sourceTree = "<group>"; };
+		2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.debug.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.debug.xcconfig"; sourceTree = "<group>"; };
 		331159CC27D26773003B0F06 /* MagazinesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazinesList.swift; sourceTree = "<group>"; };
 		331159D627D41C89003B0F06 /* Image+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extensions.swift"; sourceTree = "<group>"; };
 		3334F49F2705269800CF0987 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -106,10 +107,10 @@
 		335E692527DFDC2700FBDE3A /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		33913A0B27D89E0A00C5718D /* TabBarReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarReader.swift; sourceTree = "<group>"; };
 		33AE4CEC27403F670001BA5B /* UserMutations.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserMutations.graphql; sourceTree = "<group>"; };
+		39F9DEFA44D733F76F2031E2 /* Pods-Volume.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.release.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.release.xcconfig"; sourceTree = "<group>"; };
 		502E3EA22757D3C6005DA441 /* WeeklyDebriefView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyDebriefView.swift; sourceTree = "<group>"; };
 		502E3EA42757F774005DA441 /* StatisticView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticView.swift; sourceTree = "<group>"; };
 		50C360532759482A006CDB2E /* DebriefArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebriefArticleView.swift; sourceTree = "<group>"; };
-		73CCD70394C4621A0C4211D4 /* Pods-Volume.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.release.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.release.xcconfig"; sourceTree = "<group>"; };
 		7E23DFD1254A05EF0001C3A3 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		7E369DF525EEA41300FC0419 /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		7E369E1625EED97500FC0419 /* Secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
@@ -153,8 +154,7 @@
 		A2A4CB1B27D5276D00774C70 /* Magazine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Magazine.swift; sourceTree = "<group>"; };
 		A2A5CC0F27D567EA0000F377 /* MagazineCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineCell.swift; sourceTree = "<group>"; };
 		A2B4DF3127D9AAB000440184 /* MagazineDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineDetail.swift; sourceTree = "<group>"; };
-		ACDB01FFF9D60A537732BD25 /* Pods-Volume.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.debug.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.debug.xcconfig"; sourceTree = "<group>"; };
-		DDD49BC6A6691BB636B1EBD1 /* Pods_Volume.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Volume.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA62FF4EAFC9DE4F9A2FFE3B /* Pods_Volume.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Volume.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,8 +162,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				54E326C736B9BE60F5002B5D /* Pods_Volume.framework in Frameworks */,
 				95AC9DCB2637C09B000B4BEE /* NetworkExtension.framework in Frameworks */,
+				9F35EE5AB6332722632EAF82 /* Pods_Volume.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -244,7 +244,7 @@
 			isa = PBXGroup;
 			children = (
 				95AC9DCA2637C09B000B4BEE /* NetworkExtension.framework */,
-				DDD49BC6A6691BB636B1EBD1 /* Pods_Volume.framework */,
+				DA62FF4EAFC9DE4F9A2FFE3B /* Pods_Volume.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -376,8 +376,8 @@
 		83C84BDB5D19AF58134A64D3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				ACDB01FFF9D60A537732BD25 /* Pods-Volume.debug.xcconfig */,
-				73CCD70394C4621A0C4211D4 /* Pods-Volume.release.xcconfig */,
+				2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */,
+				39F9DEFA44D733F76F2031E2 /* Pods-Volume.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -398,12 +398,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7ED7C347252D117B0078B1BD /* Build configuration list for PBXNativeTarget "Volume" */;
 			buildPhases = (
-				8223A897A0C18BC0DC38FA77 /* [CP] Check Pods Manifest.lock */,
+				6112D0C302AD1E00FB17F87E /* [CP] Check Pods Manifest.lock */,
 				063EED1A257BF7F7002136EE /* Generate Apollo GraphQL API */,
 				7ED7C32F252D117A0078B1BD /* Sources */,
 				7ED7C330252D117A0078B1BD /* Frameworks */,
 				7ED7C331252D117A0078B1BD /* Resources */,
-				A8D251E26B6BF8155FE3D472 /* [CP] Embed Pods Frameworks */,
+				11A717B14891FEDF6F15C430 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -486,7 +486,24 @@
 			shellPath = /bin/sh;
 			shellScript = "SCRIPT_PATH=\"${PODS_ROOT}/Apollo/scripts\"\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\n\"${SCRIPT_PATH}\"/run-bundled-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile=\"Networking/schema.json\" Networking/API.swift\n";
 		};
-		8223A897A0C18BC0DC38FA77 /* [CP] Check Pods Manifest.lock */ = {
+		11A717B14891FEDF6F15C430 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6112D0C302AD1E00FB17F87E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -506,23 +523,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A8D251E26B6BF8155FE3D472 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Volume/Pods-Volume-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -725,7 +725,7 @@
 		};
 		7ED7C348252D117B0078B1BD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ACDB01FFF9D60A537732BD25 /* Pods-Volume.debug.xcconfig */;
+			baseConfigurationReference = 2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
@@ -753,7 +753,7 @@
 		};
 		7ED7C349252D117B0078B1BD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 73CCD70394C4621A0C4211D4 /* Pods-Volume.release.xcconfig */;
+			baseConfigurationReference = 39F9DEFA44D733F76F2031E2 /* Pods-Volume.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;


### PR DESCRIPTION
## Overview

Title. We haven't updated them in a while. 

## Changes Made

- Alphabetized `Podfile`
- Deleted `Podfile.lock` and let it re-generate w/ most up-to-date pods. 
- POD UPDATES:
  - Apollo 0.49.1 -> 0.53.0: better Xcode 14 support 
  - SDWebImageSwiftUI 2.0.2 -> 2.1.0: fixes an annoying warning on the console about mutating data on the main thread
  - Google pods: updates related to AppDevAnalytics dependency

## Test Coverage

- Manual testing.
  - Apollo: codegen & network requests all work as expected.
  - Web images: still loading & showing up.
  - Analytics: still sending & displaying endless console messages.
