### PR TITLE
Fix notifications & deeplinking

### DIFF
--- a/Volume/View Models/HomeViewModel.swift
+++ b/Volume/View Models/HomeViewModel.swift
@@ -169,7 +169,6 @@ extension HomeView {
         // MARK: Deeplink
 
         func handleURL(_ url: URL) {
-            openArticleFromDeeplink = false
             if url.isDeeplink, let id = url.parameters["id"] {
                 deeplinkID = id
                 openArticleFromDeeplink = true

--- a/Volume/View Models/HomeViewModel.swift
+++ b/Volume/View Models/HomeViewModel.swift
@@ -169,6 +169,7 @@ extension HomeView {
         // MARK: Deeplink
 
         func handleURL(_ url: URL) {
+            openArticleFromDeeplink = false
             if url.isDeeplink, let id = url.parameters["id"] {
                 deeplinkID = id
                 openArticleFromDeeplink = true

--- a/Volume/Views/MainView/HomeView.swift
+++ b/Volume/Views/MainView/HomeView.swift
@@ -24,33 +24,13 @@ struct HomeView: View {
     }
 
     var body: some View {
-        List {
-            Group {
-                trendingArticlesSection
-                weeklyDebriefButton
-                followedArticlesSection
-                unfollowedArticlesSection
-                deepNavigationLink
-            }
-            .listSectionSeparator(.hidden)
-            .listRowSeparator(.hidden)
-            .listRowInsets(EdgeInsets(top: 0, leading: Constants.listHorizontalPadding, bottom: 0, trailing: Constants.listHorizontalPadding))
-            .listRowBackground(Color.clear)
-        }
+        listContent
         .toolbar {
             ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
                 Image.volume.logo
                     .foregroundColor(.red)
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
-        .listStyle(.plain)
-        .refreshable {
-            viewModel.fetchContent()
-        }
-        .modifier(ListBackgroundModifier())
-        .background(Constants.backgroundColor)
-        .disabled(viewModel.disableScrolling)
         .onAppear {
             viewModel.setupEnvironment(networkState: networkState, userData: userData)
             viewModel.fetchContent()
@@ -65,16 +45,27 @@ struct HomeView: View {
         }
     }
 
-    // MARK: Deeplink
-
-    private var deepNavigationLink: some View {
-        // Invisible navigation link
-        // Only opens if application is opened through deeplink w/ valid article
-        Group {
-            if let articleID = viewModel.deeplinkID {
-                NavigationLink("", destination: BrowserView(initType: .fetchRequired(articleID), navigationSource: .morePublications), isActive: $viewModel.openArticleFromDeeplink)
+    private var listContent: some View {
+        List {
+            Group {
+                trendingArticlesSection
+                weeklyDebriefButton
+                followedArticlesSection
+                unfollowedArticlesSection
             }
+            .listSectionSeparator(.hidden)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: 0, leading: Constants.listHorizontalPadding, bottom: 0, trailing: Constants.listHorizontalPadding))
+            .listRowBackground(Color.clear)
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .listStyle(.plain)
+        .refreshable {
+            viewModel.fetchContent()
+        }
+        .modifier(ListBackgroundModifier())
+        .background(background)
+        .disabled(viewModel.disableScrolling)
     }
 
     // MARK: Sections
@@ -107,34 +98,6 @@ struct HomeView: View {
                 .foregroundColor(.black)
         }
         .background(headerGradient)
-    }
-
-    private var weeklyDebriefButton: some View {
-        Group {
-            switch viewModel.weeklyDebrief {
-            case .loading, .reloading:
-                SkeletonView()
-            case .results(let weeklyDebrief):
-                if let _ = weeklyDebrief {
-                    WeeklyDebriefButton(buttonPressed: $viewModel.isWeeklyDebriefOpen)
-                }
-            }
-        }
-        .padding(.top, Constants.weeklyDebriefTopPadding)
-        .padding(.bottom, Constants.rowVerticalPadding)
-    }
-
-    private var weeklyDebriefView: some View {
-        Group {
-            if let weeklyDebrief = userData.weeklyDebrief {
-                WeeklyDebriefView(
-                    isOpen: $viewModel.isWeeklyDebriefOpen,
-                    onOpenArticleUrl: $viewModel.deeplinkID,
-                    openedURL: $viewModel.openArticleFromDeeplink,
-                    weeklyDebrief: weeklyDebrief
-                )
-            }
-        }
     }
 
     private var followedArticlesSection: some View {
@@ -195,6 +158,36 @@ struct HomeView: View {
         .background(headerGradient)
     }
 
+    // MARK: Weekly Debrief
+
+    private var weeklyDebriefButton: some View {
+        Group {
+            switch viewModel.weeklyDebrief {
+            case .loading, .reloading:
+                SkeletonView()
+            case .results(let weeklyDebrief):
+                if let _ = weeklyDebrief {
+                    WeeklyDebriefButton(buttonPressed: $viewModel.isWeeklyDebriefOpen)
+                }
+            }
+        }
+        .padding(.top, Constants.weeklyDebriefTopPadding)
+        .padding(.bottom, Constants.rowVerticalPadding)
+    }
+
+    private var weeklyDebriefView: some View {
+        Group {
+            if let weeklyDebrief = userData.weeklyDebrief {
+                WeeklyDebriefView(
+                    isOpen: $viewModel.isWeeklyDebriefOpen,
+                    onOpenArticleUrl: $viewModel.deeplinkID,
+                    openedURL: $viewModel.openArticleFromDeeplink,
+                    weeklyDebrief: weeklyDebrief
+                )
+            }
+        }
+    }
+
     // MARK: Supporting Views
 
     private var headerGradient: some View {
@@ -202,6 +195,26 @@ struct HomeView: View {
             colors: [Constants.backgroundColor, Constants.backgroundColor.opacity(0)],
             startPoint: .top, endPoint: .bottom
         )
+    }
+
+    private var background: some View {
+        ZStack {
+            deepNavigationLink
+            Constants.backgroundColor
+        }
+    }
+
+    private var deepNavigationLink: some View {
+        // Invisible navigation link
+        // Only opens if application is opened through deeplink w/ valid article
+        Group {
+            if let articleID = viewModel.deeplinkID {
+                NavigationLink(Constants.browserViewNavigationTitleKey, isActive: $viewModel.openArticleFromDeeplink) {
+                    BrowserView(initType: .fetchRequired(articleID), navigationSource: .morePublications)
+                }
+                .hidden()
+            }
+        }
     }
 }
 
@@ -215,6 +228,7 @@ extension HomeView {
         static let volumeMessageBottomPadding: CGFloat = 0
         static let followedArticlesSectionTitle: String = "Following"
         static let unfollowedArticlesSectionTitle: String = "Other Articles"
+        static let browserViewNavigationTitleKey: String = "BrowserView"
 
         static var backgroundColor: Color {
             // Prevent inconsistency w/ List background in lower iOS versions


### PR DESCRIPTION
## Overview

Title. I caused this problem in the home screen refactor, and now it's fixed. 

## Changes Made

- Moved `NavigationLink` to the background. Reasoning?
  - The reason notifications & deeplinks weren't working is because the invisible `NavigationLink` was the last element of the `List`. This means it doesn't load until we scroll to the bottom, which based on the pagination PR, sometimes never happens. Moving the `NavigationLink` to the top of the list creates a new empty cell with just the list, thus creating an empty space we don't want. So I put it in the background. 
- Further rearranged some variables to make the file more readable. There were too many decorators on the `List` object that modified the whole view, not the `List` itself, so I separated those. 

## Test Coverage

Playtesting. See screen recordings. 

## Related PRs or Issues

Read [this article](https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types) if interested. TL;DR, Apple is deprecating `NavigationLink(isActive:)` from iOS 16 onwards and introducing a better way of programmatic navigation in SwiftUI. This also makes it harder to implement deeplinks, though. 

## Screenshots

<details>

  <summary>Deeplinks</summary>

  <table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/13712511/200999630-eff19599-179a-49c6-9540-324acc4d2b26.MP4" ></td>
    <td><img src="https://user-images.githubusercontent.com/13712511/200999635-7021b8a1-7b74-4f37-a61e-2953e8877843.MP4" ></td>
  </tr>
 </table>
 
</details>


<details>

  <summary>Notifications</summary>

  <table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/13712511/200999623-c465644e-032e-493c-ae0a-5863e3f45b60.MP4" ></td>
    <td><img src="https://user-images.githubusercontent.com/13712511/200999631-e890b088-8cb9-407f-84ad-e49988c8c96d.MP4" ></td>
  </tr>
 </table>
 
</details>


