### PR TITLE
Fix settings background, refreshing, and remove skeletonView animation

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -747,7 +747,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -759,7 +759,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -777,7 +777,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -789,7 +789,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.5;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -27,6 +27,10 @@ class Network {
     func publisher<Mutation: GraphQLMutation>(for mutation: Mutation) -> OperationPublisher<Mutation.Data> {
         OperationPublisher<Mutation.Data>(client: apollo, operation: MutationOperation(mutation: mutation).asAny)
     }
+
+    func clearCache() {
+        apollo.clearCache()
+    }
 }
 
 enum WrappedGraphQLError: Error {

--- a/Volume/Supporting Views/SkeletonView.swift
+++ b/Volume/Supporting Views/SkeletonView.swift
@@ -9,37 +9,9 @@
 import SwiftUI
 
 struct SkeletonView: View {
-    @State private var animate = false
-    @State private var onScreen = true
-
-    private var animation: Animation {
-        Animation
-            .easeInOut(duration: Constants.duration)
-            .repeatForever(autoreverses: true)
-    }
-
     var body: some View {
         Rectangle()
             .fill(Color.volume.veryLightGray)
-            .opacity(animate ? Constants.minOpacity : Constants.maxOpacity)
             .transition(.opacity)
-            .onAppear {
-                if onScreen {
-                    withAnimation(animation) {
-                        animate.toggle()
-                    }
-                }
-            }
-            .onDisappear {
-                onScreen = false
-            }
-    }
-}
-
-extension SkeletonView {
-    private struct Constants {
-        static let minOpacity = 0.25
-        static let maxOpacity = 1.0
-        static let duration = 1.0
     }
 }

--- a/Volume/View Models/HomeViewModel.swift
+++ b/Volume/View Models/HomeViewModel.swift
@@ -12,7 +12,6 @@ import SwiftUI
 extension HomeView {
     @MainActor class ViewModel: ObservableObject {
         typealias ArticlesResultPublisher = Publishers.Map<OperationPublisher<GetArticlesByPublicationSlugsQuery.Data>, [ArticleFields]>
-        typealias DataState<T> = MainView.TabState<T>
 
         private struct Constants {
             static let pageSize: Double = 10
@@ -22,36 +21,33 @@ extension HomeView {
         var networkState: NetworkState?
         var userData: UserData?
 
-        @Published var trendingArticles: DataState<[Article]> = .loading
-        @Published var weeklyDebrief: DataState<WeeklyDebrief?> = .loading
-        @Published var followedArticles: DataState<[Article]> = .loading
-        @Published var unfollowedArticles: DataState<[Article]> = .loading
+        @Published var trendingArticles: [Article]? = nil
+        @Published var weeklyDebrief: WeeklyDebrief? = nil
+        @Published var followedArticles: [Article]? = nil
+        @Published var unfollowedArticles: [Article]? = nil
+
         @Published var hasMoreFollowedArticlePages = true
         @Published var hasMoreUnfollowedArticlePages = true
         @Published var isWeeklyDebriefOpen: Bool = false
         @Published var deeplinkID: String? = nil
         @Published var openArticleFromDeeplink: Bool = false
 
-        private var publicationSlugs: MainView.TabState<[String]> = .loading
+        private var publicationSlugs: [String]? = nil
         private var queryBag = Set<AnyCancellable>()
-
-        /// Returns empty list if still loading
-        private var loadedPublicationSlugs: [String] {
-            switch publicationSlugs {
-            case .loading:
-                return []
-            case .results(let slugs), .reloading(let slugs):
-                return slugs
-            }
-        }
 
         func setupEnvironment(networkState: NetworkState, userData: UserData) {
             self.networkState = networkState
             self.userData = userData
         }
 
-        var followedPublicationSlugs: [String] {
+        private var followedPublicationSlugs: [String] {
             userData?.followedPublicationSlugs ?? []
+        }
+
+        private var unfollowedPublicationSlugs: [String] {
+            publicationSlugs?.filter { slug -> Bool in
+                !followedPublicationSlugs.contains(slug)
+            } ?? []
         }
 
         var hasFollowedPublications: Bool {
@@ -59,25 +55,39 @@ extension HomeView {
         }
 
         var disableScrolling: Bool {
-            switch trendingArticles {
-            case .loading:
-                return true
-            default:
-                return false
-            }
+            trendingArticles == .none
         }
 
         // MARK: Requests
 
-        func fetchContent() {
-            trendingArticles = .loading
-            followedArticles = .loading
-            weeklyDebrief = .loading
-            unfollowedArticles = .loading
-
+        func fetchContent() async {
             fetchTrendingArticles()
             fetchWeeklyDebrief()
-            fetchFirstPage()
+            await fetchFirstPage()
+        }
+
+        func refreshContent() async {
+            Network.shared.clearCache()
+            queryBag.removeAll()
+
+            trendingArticles = nil
+            followedArticles = nil
+            weeklyDebrief = nil
+            unfollowedArticles = nil
+            publicationSlugs = nil
+
+            await fetchContent()
+        }
+
+        func fetchTrendingArticles() {
+            Network.shared.publisher(for: GetTrendingArticlesQuery(limit: Constants.trendingArticleLimit))
+                .map { $0.articles.map(\.fragments.articleFields) }
+                .sink { [weak self] completion in
+                    self?.networkState?.handleCompletion(screen: .home, completion)
+                } receiveValue: { [weak self] articleFieldsList in
+                    self?.trendingArticles = [Article](articleFieldsList)
+                }
+                .store(in: &queryBag)
         }
 
         func fetchWeeklyDebrief() {
@@ -98,13 +108,13 @@ extension HomeView {
                             #if DEBUG
                             print("Error: GetWeeklyDebrief failed on HomeView: field \"weeklyDebrief\" is nil.")
                             #endif
-                            self?.weeklyDebrief = .results(nil)
+                            self?.weeklyDebrief = nil
                             return
                         }
 
                         let weeklyDebrief = WeeklyDebrief(from: weeklyDebriefFields)
                         self?.userData?.weeklyDebrief = weeklyDebrief
-                        self?.weeklyDebrief = .results(weeklyDebrief)
+                        self?.weeklyDebrief = weeklyDebrief
                         self?.isWeeklyDebriefOpen = !weeklyDebrief.isExpired
                     }
                     .store(in: &queryBag)
@@ -116,7 +126,7 @@ extension HomeView {
                     fetch()
                 } else {
                     // Cached WD still fresh, stop loading state
-                    weeklyDebrief = .results(cachedWeeklyDebrief)
+                    weeklyDebrief = cachedWeeklyDebrief
                 }
             } else {
                 // No existing WD, query new one
@@ -124,39 +134,39 @@ extension HomeView {
             }
         }
 
-        func fetchTrendingArticles() {
-            // TODO: filter trending articles from feed?
-            Network.shared.publisher(for: GetTrendingArticlesQuery(limit: Constants.trendingArticleLimit))
-                .map { $0.articles.map(\.fragments.articleFields) }
-                .sink { [weak self] completion in
-                    self?.networkState?.handleCompletion(screen: .home, completion)
-                } receiveValue: { articleFieldsList in
-                    self.trendingArticles = .results([Article](articleFieldsList))
-                }
-                .store(in: &queryBag)
-        }
-
-        func fetchFirstPage() {
-            Network.shared.publisher(for: GetAllPublicationSlugsQuery())
-                .map { $0.publications.map(\.slug) }
-                .flatMap { slugs -> ArticlesResultPublisher in
-                    self.publicationSlugs = .results(slugs)
-                    let query = GetArticlesByPublicationSlugsQuery(slugs: self.followedPublicationSlugs, limit: Constants.pageSize)
-                    return Network.shared.publisher(for: query)
-                        .map { $0.articles.map(\.fragments.articleFields) }
-                }
-                .sink { [weak self] completion in
-                    self?.networkState?.handleCompletion(screen: .home, completion)
-                } receiveValue: { [weak self] articleFields in
-                    self?.updateArticles(followed: true, with: articleFields)
-                }
-                .store(in: &queryBag)
+        func fetchFirstPage() async {
+            await withCheckedContinuation { continuation in
+                Network.shared.publisher(for: GetAllPublicationSlugsQuery())
+                    .map { $0.publications.map(\.slug) }
+                    .flatMap { [weak self] slugs -> ArticlesResultPublisher in
+                        self?.publicationSlugs = slugs
+                        let query = GetArticlesByPublicationSlugsQuery(
+                            slugs: self?.followedPublicationSlugs ?? [],
+                            limit: Constants.pageSize
+                        )
+                        return Network.shared.publisher(for: query)
+                            .map { $0.articles.map(\.fragments.articleFields) }
+                    }
+                    .sink { [weak self] completion in
+                        self?.networkState?.handleCompletion(screen: .home, completion)
+                    } receiveValue: { [weak self] articleFields in
+                        self?.updateArticles(followed: true, with: articleFields)
+                        continuation.resume()
+                    }
+                    .store(in: &queryBag)
+            }
         }
 
         func fetchPage(followed: Bool) {
-            let slugs = followed ? followedPublicationSlugs : loadedPublicationSlugs
+            let slugs = followed ? followedPublicationSlugs : unfollowedPublicationSlugs
             Network.shared
-                .publisher(for: GetArticlesByPublicationSlugsQuery(slugs: slugs, limit: Constants.pageSize, offset: offset(for: followed ? followedArticles : unfollowedArticles)))
+                .publisher(
+                    for: GetArticlesByPublicationSlugsQuery(
+                        slugs: slugs,
+                        limit: Constants.pageSize,
+                        offset: offset(for: followed ? followedArticles : unfollowedArticles)
+                    )
+                )
                 .map { $0.articles.map(\.fragments.articleFields) }
                 .sink { [weak self] completion in
                     self?.networkState?.handleCompletion(screen: .home, completion)
@@ -177,30 +187,25 @@ extension HomeView {
 
         // MARK: Helpers
 
-        private func offset(for articles: MainView.TabState<[Article]>) -> Double {
-            switch articles {
-            case .loading, .reloading:
-                return 0
-            case .results(let articles):
-                return Double(articles.count)
-            }
+        private func offset(for articles: [Article]?) -> Double {
+            Double(articles?.count ?? 0)
         }
 
         private func updateArticles(followed: Bool, with articleFields: [ArticleFields]) {
             let newArticles = [Article](articleFields)
 
             switch followed ? followedArticles : unfollowedArticles {
-            case .loading, .reloading:
+            case .none:
                 if followed {
-                    followedArticles = .results(newArticles)
+                    followedArticles = newArticles
                 } else {
-                    unfollowedArticles = .results(newArticles)
+                    unfollowedArticles = newArticles
                 }
-            case .results(let articles):
+            case .some(let articles):
                 if followed {
-                    followedArticles = .results(articles + newArticles)
+                    followedArticles = articles + newArticles
                 } else {
-                    unfollowedArticles = .results(articles + newArticles)
+                    unfollowedArticles = articles + newArticles
                 }
             }
 

--- a/Volume/Views/SettingsView.swift
+++ b/Volume/Views/SettingsView.swift
@@ -35,16 +35,10 @@ struct SettingsView: View {
             }
         }
         .navigationBarTitle(Text("Settings"), displayMode: .inline)
-        .background(Color.white)
+        .background(Color.volume.backgroundGray)
     }
 }
 
 enum NestedSettingsView: String {
     case aboutUs
 }
-
-//struct SettingsView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        SettingsView()
-//    }
-//}


### PR DESCRIPTION
## Overview

1. Settings page background was white instead of gray, fixed that. 
2. Refreshing wasn't working properly, fixed that. 
3. SkeletonView animation was causing some weird SwiftUI bouncing issue. My previous fixes didn't resolve it so I opted to remove the animation entirely, since loading times are shorter now anyway. 

## Changes Made

- Added new `clearCache` function to `Network` since Apollo caches the results of queries that aren't distinct. This was breaking refreshing. 

## Test Coverage

Playtesting. See screen recordings. 

## Related PRs

See #110 for screen recording of bouncing bug

## Screenshots

<details>

  <summary>Bug fixes</summary>

  <table>
  <tr>
     <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/13712511/202327314-f309ba3a-9997-426b-9203-d16fd4e39974.mp4" ></td>
    <td><img src="https://user-images.githubusercontent.com/13712511/202327312-0cc9d2f3-0100-4c14-b96e-19f19e81ab50.mp4" ></td>
  </tr>
 </table>
 

</details>

