### PR TITLE
Vin/mags improvements

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -836,7 +836,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -854,7 +854,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -866,7 +866,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.2.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		06B80D13257DC18600F3BF9B /* WebImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B80D12257DC18600F3BF9B /* WebImage+Extension.swift */; };
 		06DBC684257DE35F00B6A453 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBC683257DE35F00B6A453 /* UserData.swift */; };
 		06EC2D24259CED0500FE0A71 /* PublicationDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */; };
+		2E05005B29C65B82001B4131 /* MagazinesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E05005A29C65B82001B4131 /* MagazinesListViewModel.swift */; };
 		2EB5568829B9485700794423 /* MagsScrollbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568729B9485700794423 /* MagsScrollbarView.swift */; };
 		2EB5568C29B94A5600794423 /* PageIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568B29B94A5600794423 /* PageIndicatorView.swift */; };
 		331159CD27D26773003B0F06 /* MagazinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331159CC27D26773003B0F06 /* MagazinesList.swift */; };
@@ -120,6 +121,7 @@
 		06B80D12257DC18600F3BF9B /* WebImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebImage+Extension.swift"; sourceTree = "<group>"; };
 		06DBC683257DE35F00B6A453 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationDetailHeader.swift; sourceTree = "<group>"; };
+		2E05005A29C65B82001B4131 /* MagazinesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazinesListViewModel.swift; sourceTree = "<group>"; };
 		2EB5568729B9485700794423 /* MagsScrollbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagsScrollbarView.swift; sourceTree = "<group>"; };
 		2EB5568B29B94A5600794423 /* PageIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageIndicatorView.swift; sourceTree = "<group>"; };
 		2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.debug.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.debug.xcconfig"; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 				7E9E4718262808AC007E8E6C /* SettingsPageRow.swift */,
 				333EB8A82909ECBA00EA9950 /* HomeViewModel.swift */,
 				3360B9DD29274B9500A923A6 /* PublicationContentViewModel.swift */,
+				2E05005A29C65B82001B4131 /* MagazinesListViewModel.swift */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -637,6 +640,7 @@
 				922FE30B29341A5400E14911 /* SearchTabBar.swift in Sources */,
 				33538BEE2745C477009DD191 /* WeeklyDebrief.swift in Sources */,
 				7E416C322561D7870010D70B /* Header.swift in Sources */,
+				2E05005B29C65B82001B4131 /* MagazinesListViewModel.swift in Sources */,
 				06B23228258EDDA9006D9A53 /* SkeletonView.swift in Sources */,
 				3392D71E2937C021005165F6 /* ReadableContent.swift in Sources */,
 				33E851A6290AE6ED004453D2 /* ListBackgroundModifier.swift in Sources */,

--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -23,9 +23,9 @@
 		06DBC684257DE35F00B6A453 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBC683257DE35F00B6A453 /* UserData.swift */; };
 		06EC2D24259CED0500FE0A71 /* PublicationDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */; };
 		2E05005B29C65B82001B4131 /* MagazinesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E05005A29C65B82001B4131 /* MagazinesListViewModel.swift */; };
+		2E05005D29C66999001B4131 /* MagazinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E05005C29C66999001B4131 /* MagazinesList.swift */; };
 		2EB5568829B9485700794423 /* MagsScrollbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568729B9485700794423 /* MagsScrollbarView.swift */; };
 		2EB5568C29B94A5600794423 /* PageIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568B29B94A5600794423 /* PageIndicatorView.swift */; };
-		331159CD27D26773003B0F06 /* MagazinesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331159CC27D26773003B0F06 /* MagazinesList.swift */; };
 		331159D727D41C89003B0F06 /* Image+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331159D627D41C89003B0F06 /* Image+Extensions.swift */; };
 		3334F4A02705269800CF0987 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3334F49F2705269800CF0987 /* AppDelegate.swift */; };
 		333EB8A92909ECBA00EA9950 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EB8A82909ECBA00EA9950 /* HomeViewModel.swift */; };
@@ -122,10 +122,10 @@
 		06DBC683257DE35F00B6A453 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		06EC2D23259CED0500FE0A71 /* PublicationDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationDetailHeader.swift; sourceTree = "<group>"; };
 		2E05005A29C65B82001B4131 /* MagazinesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazinesListViewModel.swift; sourceTree = "<group>"; };
+		2E05005C29C66999001B4131 /* MagazinesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazinesList.swift; sourceTree = "<group>"; };
 		2EB5568729B9485700794423 /* MagsScrollbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagsScrollbarView.swift; sourceTree = "<group>"; };
 		2EB5568B29B94A5600794423 /* PageIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageIndicatorView.swift; sourceTree = "<group>"; };
 		2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.debug.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.debug.xcconfig"; sourceTree = "<group>"; };
-		331159CC27D26773003B0F06 /* MagazinesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazinesList.swift; sourceTree = "<group>"; };
 		331159D627D41C89003B0F06 /* Image+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extensions.swift"; sourceTree = "<group>"; };
 		3334F49F2705269800CF0987 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		333EB8A82909ECBA00EA9950 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -273,7 +273,7 @@
 				95A79FB72622296800CADF88 /* ConnectionFailedView.swift */,
 				06A8E2522575429200C28C68 /* MainView.swift */,
 				333EB8AA2909EE5400EA9950 /* HomeView.swift */,
-				331159CC27D26773003B0F06 /* MagazinesList.swift */,
+				2E05005C29C66999001B4131 /* MagazinesList.swift */,
 				A2B4DF3127D9AAB000440184 /* MagazineReaderView.swift */,
 				7E8658A7254B719A002DEE68 /* PublicationList.swift */,
 				95A79FB32622255D00CADF88 /* TabContainer.swift */,
@@ -645,6 +645,7 @@
 				3392D71E2937C021005165F6 /* ReadableContent.swift in Sources */,
 				33E851A6290AE6ED004453D2 /* ListBackgroundModifier.swift in Sources */,
 				BC72AEBA29259D4500209573 /* API.swift in Sources */,
+				2E05005D29C66999001B4131 /* MagazinesList.swift in Sources */,
 				06662888257F204E006FEBCF /* Secrets.swift in Sources */,
 				061DB39725571D760038BEF5 /* Font+Extension.swift in Sources */,
 				3334F4A02705269800CF0987 /* AppDelegate.swift in Sources */,
@@ -672,7 +673,6 @@
 				7ED7C33B252D117A0078B1BD /* ContentView.swift in Sources */,
 				06EC2D24259CED0500FE0A71 /* PublicationDetailHeader.swift in Sources */,
 				2EB5568829B9485700794423 /* MagsScrollbarView.swift in Sources */,
-				331159CD27D26773003B0F06 /* MagazinesList.swift in Sources */,
 				95A79FB42622255D00CADF88 /* TabContainer.swift in Sources */,
 				33913A0C27D89E0A00C5718D /* TabBarReader.swift in Sources */,
 				7EA0BB502624DF7C00A1652E /* AboutUsView.swift in Sources */,

--- a/Volume/Networking/MagazineQueries.graphql
+++ b/Volume/Networking/MagazineQueries.graphql
@@ -13,6 +13,12 @@ fragment magazineFields on Magazine {
 
 # MARK: - Mag Page
 
+query GetAllMagazines($limit: Float!, $offset: Float!) {
+  magazines: getAllMagazines(limit: $limit, offset: $offset) {
+    ...magazineFields
+  }
+}
+
 query GetAllMagazineSemesters($limit: Float!) {
   magazines: getAllMagazines(limit: $limit) {
     semester

--- a/Volume/Supporting Views/SemesterMenuView.swift
+++ b/Volume/Supporting Views/SemesterMenuView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SemesterMenuView: View {
 
     @Binding var selection: String?
-    let options: [String]
+    var options: [String]
 
     var body: some View {
         Menu {
@@ -25,7 +25,7 @@ struct SemesterMenuView: View {
                 Text(Self.format(semesterString: selection ?? options.last ?? Constants.semesterPlaceholder))
                     .font(.helveticaNeueMedium(size: Constants.fontSize))
                     .fixedSize()
-
+                
                 Image("down-arrow")
                     .resizable()
                     .renderingMode(.template)
@@ -46,6 +46,8 @@ struct SemesterMenuView: View {
 extension SemesterMenuView {
 
     private static func format(semesterString: String) -> String {
+        if (semesterString == "all") { return "All semesters" }
+        
         let prefix = semesterString.prefix(2)
         let suffix = semesterString.suffix(2)
 

--- a/Volume/Supporting Views/SemesterMenuView.swift
+++ b/Volume/Supporting Views/SemesterMenuView.swift
@@ -46,7 +46,7 @@ struct SemesterMenuView: View {
 extension SemesterMenuView {
 
     private static func format(semesterString: String) -> String {
-        if (semesterString == "all") { return "All semesters" }
+        if semesterString == "all" { return "All semesters" }
         
         let prefix = semesterString.prefix(2)
         let suffix = semesterString.suffix(2)

--- a/Volume/View Models/MagazinesListViewModel.swift
+++ b/Volume/View Models/MagazinesListViewModel.swift
@@ -1,0 +1,175 @@
+//
+//  MagazinesListViewModel.swift
+//  Volume
+//
+//  Created by Vin Bui on 3/18/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+import Combine
+
+extension MagazinesList {
+    
+    @MainActor
+    class ViewModel: ObservableObject {
+        @Published var deeplinkId: String?
+        @Published var openMagazineFromDeeplink = false
+        @Published var sectionQueries: SectionQueries = (nil, nil)
+        @Published var sectionStates: SectionStates = (.loading, .loading)
+        @Published var selectedSemester: String?
+        @Published var allSemesters: [String]? = nil
+        @Published var queryBag = Set<AnyCancellable>()
+                
+        var networkState: NetworkState = NetworkState()
+        private var numMagsLoaded: Double = 0
+        private var offset: Double = 0
+
+        private struct Constants {
+            static let allMagazinesLimit: Double = 5
+            static let featuredMagazinesLimit: Double = 7
+            static let animationDuration = 0.1
+        }
+        
+        // MARK: Requests
+
+        func fetchContent(_ done: @escaping () -> Void = { }) {
+            guard sectionStates.featuredMagazines.isLoading || sectionStates.magazinesBySemester.isLoading else { return }
+            
+            fetchFeaturedMagazines(done)
+            fetchMagazineSemesters()
+        }
+        
+        func fetchFeaturedMagazines(_ done: @escaping () -> Void = { }) {
+            sectionQueries.featuredMagazines = Network.shared.publisher(for: GetFeaturedMagazinesQuery(limit: Constants.featuredMagazinesLimit))
+                .compactMap {
+                    $0.magazines?.map(\.fragments.magazineFields)
+                }
+                .sink { [weak self] completion in
+                    self?.networkState.handleCompletion(screen: .magazines, completion)
+                } receiveValue: { [weak self] magazineFields in
+                    Task {
+                        let featuredMagazines = await [Magazine](magazineFields)
+                        withAnimation(.linear(duration: Constants.animationDuration)) {
+                            self?.sectionStates.featuredMagazines = .results(featuredMagazines)
+                        }
+                        done()
+                    }
+                }
+        }
+
+        func fetchMagazineSemesters() {
+            // TODO: replace logic when backend implements Publication.getMagazineSemesters
+            Network.shared.publisher(
+                for: GetAllMagazineSemestersQuery(limit: 100)
+            )
+            .map { $0.magazines.map(\.semester) }
+            .sink { [weak self] completion in
+                self?.networkState.handleCompletion(screen: .magazines, completion)
+            } receiveValue: { [weak self] semesters in
+                guard let `self` = self else { return }
+                self.allSemesters = Array(Set(semesters))
+                    .sorted(by: self.compareSemesters)
+                
+                self.allSemesters?.reverse()
+                self.allSemesters?.insert("all", at: 0)
+                self.selectedSemester = "all"
+                self.fetchAllMagazines()
+            }
+            .store(in: &queryBag)
+        }
+        
+        func fetchMagazinesBySemester(_ semester: String) {
+            sectionStates.magazinesBySemester = .loading
+
+            sectionQueries.magazinesBySemester = Network.shared.publisher(
+                for: GetMagazinesBySemesterQuery(semester: semester)
+            )
+            .map { $0.magazines.map(\.fragments.magazineFields) }
+            .sink { [weak self] completion in
+                self?.networkState.handleCompletion(screen: .magazines, completion)
+            } receiveValue: { [weak self] magazineFields in
+                Task {
+                    let magazinesBySemester = await [Magazine](magazineFields)
+                    withAnimation(.linear(duration: 0.1)) {
+                        self?.sectionStates.magazinesBySemester = .results(magazinesBySemester)
+                    }
+                }
+            }
+        }
+        
+        func fetchAllMagazines() {
+            sectionStates.magazinesBySemester = .loading
+            sectionQueries.magazinesBySemester = Network.shared.publisher(
+                for: GetAllMagazinesQuery(limit: Constants.allMagazinesLimit, offset: offset)
+            )
+            .map { $0.magazines.map(\.fragments.magazineFields) }
+            .sink { [weak self] completion in
+                self?.networkState.handleCompletion(screen: .magazines, completion)
+            } receiveValue: { [weak self] magazineFields in
+                Task {
+                    let allMagazines = await [Magazine](magazineFields)
+                    withAnimation(.linear(duration: 0.1)) {
+                        self?.sectionStates.magazinesBySemester = .results(allMagazines)
+                    }
+                }
+            }
+        }
+        
+        // MARK: Helpers
+
+        private func compareSemesters(_ s1: String, _ s2: String) -> Bool {
+            if let s1Year = Int(s1.suffix(2)),
+               let s2Year = Int(s2.suffix(2)),
+               s1Year != s2Year {
+                return s1Year < s2Year
+            }
+
+            let validSemesterStrings = ["sp", "fa"]
+            if let s1Semester = validSemesterStrings.firstIndex(of: String(s1.prefix(2))),
+               let s2Semester = validSemesterStrings.firstIndex(of: String(s2.prefix(2))) {
+                return s1Semester < s2Semester
+            }
+
+            return false
+        }
+    }
+    
+}
+
+extension MagazinesList {
+    
+    typealias ResultsPublisher = Publishers.Zip<
+        Publishers.Map<OperationPublisher<GetFeaturedMagazinesQuery.Data>, MagazineFields>,
+        Publishers.Map<OperationPublisher<GetMagazinesBySemesterQuery.Data>, MagazineFields>
+        >
+    
+    typealias SectionStates = (
+        featuredMagazines: MainView.TabState<[Magazine]>,
+        magazinesBySemester: MainView.TabState<[Magazine]>
+    )
+    
+    typealias SectionQueries = (
+        featuredMagazines: AnyCancellable?,
+        magazinesBySemester: AnyCancellable?
+    )
+
+    private static func format(semesterString: String) -> String {
+        let prefix = semesterString.prefix(2)
+        let suffix = semesterString.suffix(2)
+
+        var result = ""
+
+        switch prefix {
+        case "fa":
+            result = "Fall"
+        case "sp":
+            result = "Spring"
+        default:
+            break
+        }
+
+        return "\(result) 20\(suffix)"
+    }
+    
+}

--- a/Volume/View Models/MagazinesListViewModel.swift
+++ b/Volume/View Models/MagazinesListViewModel.swift
@@ -26,7 +26,7 @@ extension MagazinesList {
         private var offset: Double = 0
 
         private struct Constants {
-            static let allMagazinesLimit: Double = 5
+            static let allMagazinesLimit: Double = 15
             static let featuredMagazinesLimit: Double = 7
             static let animationDuration = 0.1
         }

--- a/Volume/View Models/MagazinesListViewModel.swift
+++ b/Volume/View Models/MagazinesListViewModel.swift
@@ -13,22 +13,21 @@ extension MagazinesList {
     
     @MainActor
     class ViewModel: ObservableObject {
+        @Published var allSemesters: [String]? = nil
         @Published var deeplinkId: String?
         @Published var openMagazineFromDeeplink = false
-        @Published var sectionQueries: SectionQueries = (nil, nil)
-        @Published var sectionStates: SectionStates = (.loading, .loading)
-        @Published var selectedSemester: String?
-        @Published var allSemesters: [String]? = nil
         @Published var queryBag = Set<AnyCancellable>()
+        @Published var sectionQueries: SectionQueries = (nil, nil)
+        @Published var selectedSemester: String?
+        @Published var sectionStates: SectionStates = (.loading, .loading)
                 
         var networkState: NetworkState = NetworkState()
-        private var numMagsLoaded: Double = 0
         private var offset: Double = 0
 
         private struct Constants {
             static let allMagazinesLimit: Double = 15
             static let featuredMagazinesLimit: Double = 7
-            static let animationDuration = 0.1
+            static let animationDuration: Double = 0.1
         }
         
         // MARK: Requests
@@ -91,7 +90,7 @@ extension MagazinesList {
             } receiveValue: { [weak self] magazineFields in
                 Task {
                     let magazinesBySemester = await [Magazine](magazineFields)
-                    withAnimation(.linear(duration: 0.1)) {
+                    withAnimation(.linear(duration: Constants.animationDuration)) {
                         self?.sectionStates.magazinesBySemester = .results(magazinesBySemester)
                     }
                 }
@@ -122,13 +121,13 @@ extension MagazinesList {
             if let s1Year = Int(s1.suffix(2)),
                let s2Year = Int(s2.suffix(2)),
                s1Year != s2Year {
-                return s1Year < s2Year
+                return s1Year > s2Year
             }
 
             let validSemesterStrings = ["sp", "fa"]
             if let s1Semester = validSemesterStrings.firstIndex(of: String(s1.prefix(2))),
                let s2Semester = validSemesterStrings.firstIndex(of: String(s2.prefix(2))) {
-                return s1Semester < s2Semester
+                return s1Semester > s2Semester
             }
 
             return false

--- a/Volume/Views/MainView/MagazineReaderView.swift
+++ b/Volume/Views/MainView/MagazineReaderView.swift
@@ -128,9 +128,8 @@ struct MagazineReaderView: View {
                                  : nil,
                                  alignment: .topTrailing)
                 } else {
-                    Label("Unable to retrieve magazine", systemImage: "")
-                        .labelStyle(.titleOnly)
                     PDFKitView(pdfView: pdfView, pdfDoc: PDFDocument())
+                        .overlay(ProgressView())
                 }
                 
                 if showScrollbar {

--- a/Volume/Views/MainView/MagazinesList.swift
+++ b/Volume/Views/MainView/MagazinesList.swift
@@ -2,23 +2,24 @@
 //  MagazinesList.swift
 //  Volume
 //
-//  Created by Hanzheng Li on 3/4/22.
-//  Copyright © 2022 Cornell AppDev. All rights reserved.
+//  Created by Vin Bui on 3/18/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
 //
 
-import Combine
 import SwiftUI
+import Combine
 
 struct MagazinesList: View {
     
     @EnvironmentObject private var networkState: NetworkState
     @StateObject private var viewModel = ViewModel()
     
+    // MARK: - Constants
     private struct Constants {
         static let navigationTitleKey = "MagazineReaderView"
     }
 
-    // MARK: UI
+    // MARK: - UI
     private var featureMagazinesSection: some View {
         Group {
             Header("Featured")

--- a/Volume/Views/MainView/MagazinesList.swift
+++ b/Volume/Views/MainView/MagazinesList.swift
@@ -10,111 +10,15 @@ import Combine
 import SwiftUI
 
 struct MagazinesList: View {
-    @EnvironmentObject private var networkState: NetworkState
-    @State private var deeplinkId: String?
-    @State private var openMagazineFromDeeplink = false
-    @State private var sectionQueries: SectionQueries = (nil, nil)
-    @State private var sectionStates: SectionStates = (.loading, .loading)
-    @State private var selectedSemester: String?
-    @State private var allSemesters: [String]? = nil
-    @State private var queryBag = Set<AnyCancellable>()
     
-    private var numMagsLoaded: Double = 0
-    private var offset: Double = 0
-
+    @EnvironmentObject private var networkState: NetworkState
+    @StateObject private var viewModel = ViewModel()
+    
     private struct Constants {
-        static let allMagazinesLimit: Double = 5
-        static let featuredMagazinesLimit: Double = 7
-        static let animationDuration = 0.1
         static let navigationTitleKey = "MagazineReaderView"
     }
 
-    // MARK: Requests
-
-    private func fetchContent(_ done: @escaping () -> Void = { }) {
-        guard sectionStates.featuredMagazines.isLoading || sectionStates.magazinesBySemester.isLoading else { return }
-        
-        fetchFeaturedMagazines(done)
-        fetchMagazineSemesters()
-    }
-    
-    private func fetchFeaturedMagazines(_ done: @escaping () -> Void = { }) {
-        sectionQueries.featuredMagazines = Network.shared.publisher(for: GetFeaturedMagazinesQuery(limit: Constants.featuredMagazinesLimit))
-            .compactMap {
-                $0.magazines?.map(\.fragments.magazineFields)
-            }
-            .sink { completion in
-                networkState.handleCompletion(screen: .magazines, completion)
-            } receiveValue: { magazineFields in
-                Task {
-                    let featuredMagazines = await [Magazine](magazineFields)
-                    withAnimation(.linear(duration: Constants.animationDuration)) {
-                        sectionStates.featuredMagazines = .results(featuredMagazines)
-                    }
-                    done()
-                }
-            }
-    }
-
-    private func fetchMagazineSemesters() {
-        // TODO: replace logic when backend implements Publication.getMagazineSemesters
-        Network.shared.publisher(
-            for: GetAllMagazineSemestersQuery(limit: 100)
-        )
-        .map { $0.magazines.map(\.semester) }
-        .sink { completion in
-            networkState.handleCompletion(screen: .magazines, completion)
-        } receiveValue: { semesters in
-            allSemesters = Array(Set(semesters))
-                .sorted(by: compareSemesters)
-            
-            allSemesters?.reverse()
-            allSemesters?.insert("all", at: 0)
-            selectedSemester = "all"
-            fetchAllMagazines()
-        }
-        .store(in: &queryBag)
-    }
-    
-    private func fetchMagazinesBySemester(_ semester: String) {
-        sectionStates.magazinesBySemester = .loading
-
-        sectionQueries.magazinesBySemester = Network.shared.publisher(
-            for: GetMagazinesBySemesterQuery(semester: semester)
-        )
-        .map { $0.magazines.map(\.fragments.magazineFields) }
-        .sink { completion in
-            networkState.handleCompletion(screen: .magazines, completion)
-        } receiveValue: { magazineFields in
-            Task {
-                let magazinesBySemester = await [Magazine](magazineFields)
-                withAnimation(.linear(duration: 0.1)) {
-                    sectionStates.magazinesBySemester = .results(magazinesBySemester)
-                }
-            }
-        }
-    }
-    
-    private func fetchAllMagazines() {
-        sectionStates.magazinesBySemester = .loading
-        sectionQueries.magazinesBySemester = Network.shared.publisher(
-            for: GetAllMagazinesQuery(limit: Constants.allMagazinesLimit, offset: offset)
-        )
-        .map { $0.magazines.map(\.fragments.magazineFields) }
-        .sink { completion in
-            networkState.handleCompletion(screen: .magazines, completion)
-        } receiveValue: { magazineFields in
-            Task {
-                let allMagazines = await [Magazine](magazineFields)
-                withAnimation(.linear(duration: 0.1)) {
-                    sectionStates.magazinesBySemester = .results(allMagazines)
-                }
-            }
-        }
-    }
-
     // MARK: UI
-    
     private var featureMagazinesSection: some View {
         Group {
             Header("Featured")
@@ -122,7 +26,7 @@ struct MagazinesList: View {
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 24) {
-                    switch sectionStates.featuredMagazines {
+                    switch viewModel.sectionStates.featuredMagazines {
                     case .loading, .reloading:
                         ForEach(0..<3) { _ in
                              MagazineCell.Skeleton()
@@ -149,10 +53,10 @@ struct MagazinesList: View {
                     .padding([.top, .horizontal])
 
                 Group {
-                    if let allSemesters {
+                    if let options = viewModel.allSemesters {
                         SemesterMenuView(
-                            selection: $selectedSemester,
-                            options: allSemesters
+                            selection: $viewModel.selectedSemester,
+                            options: options
                         )
                     } else {
                         SemesterMenuView.Skeleton()
@@ -164,7 +68,7 @@ struct MagazinesList: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 24) {
-                    switch sectionStates.magazinesBySemester {
+                    switch viewModel.sectionStates.magazinesBySemester {
                     case .loading, .reloading:
                         ForEach(0..<3) { _ in
                              MagazineCell.Skeleton()
@@ -182,20 +86,20 @@ struct MagazinesList: View {
             }
             .padding(.horizontal)
         }
-        .onChange(of: selectedSemester) { newValue in
-            guard let selectedSemester = selectedSemester else { return }
+        .onChange(of: viewModel.selectedSemester) { newValue in
+            guard let selectedSemester = viewModel.selectedSemester else { return }
             if selectedSemester == "all" {
-                fetchAllMagazines()
+                viewModel.fetchAllMagazines()
             } else {
-                fetchMagazinesBySemester(selectedSemester)
+                viewModel.fetchMagazinesBySemester(selectedSemester)
             }
         }
     }
 
     private var deepNavigationLink: some View {
         Group {
-            if let magazineId = deeplinkId {
-                NavigationLink(Constants.navigationTitleKey, isActive: $openMagazineFromDeeplink) {
+            if let magazineId = viewModel.deeplinkId {
+                NavigationLink(Constants.navigationTitleKey, isActive: $viewModel.openMagazineFromDeeplink) {
                     MagazineReaderView(initType: .fetchRequired(magazineId), navigationSource: .moreMagazines)
                 }
                 .hidden()
@@ -212,13 +116,13 @@ struct MagazinesList: View {
     
     var body: some View {
         RefreshableScrollView { done in
-            if case let .results(magazines) = sectionStates.featuredMagazines {
-                sectionStates.featuredMagazines = .reloading(magazines)
+            if case let .results(magazines) = viewModel.sectionStates.featuredMagazines {
+                viewModel.sectionStates.featuredMagazines = .reloading(magazines)
             }
             
-            sectionStates.magazinesBySemester = .loading
+            viewModel.sectionStates.magazinesBySemester = .loading
             
-            fetchContent(done)
+            viewModel.fetchContent(done)
         } content: {
             VStack {
                 featureMagazinesSection
@@ -227,7 +131,7 @@ struct MagazinesList: View {
                 magazinesBySemesterSection
             }
         }
-        .disabled(sectionStates.featuredMagazines.isLoading)
+        .disabled(viewModel.sectionStates.featuredMagazines.isLoading)
         .padding(.top)
         .background(background)
         .toolbar {
@@ -239,68 +143,17 @@ struct MagazinesList: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            fetchContent()
+            viewModel.networkState = networkState
+            viewModel.fetchContent()
         }
         .onOpenURL { url in
             if url.isDeeplink,
                url.contentType == .magazine,
                let id = url.parameters["id"] {
-                deeplinkId = id
-                openMagazineFromDeeplink = true
+                viewModel.deeplinkId = id
+                viewModel.openMagazineFromDeeplink = true
             }
         }
     }
-
-    // MARK: Helpers
-
-    private func compareSemesters(_ s1: String, _ s2: String) -> Bool {
-        if let s1Year = Int(s1.suffix(2)),
-           let s2Year = Int(s2.suffix(2)),
-           s1Year != s2Year {
-            return s1Year < s2Year
-        }
-
-        let validSemesterStrings = ["sp", "fa"]
-        if let s1Semester = validSemesterStrings.firstIndex(of: String(s1.prefix(2))),
-           let s2Semester = validSemesterStrings.firstIndex(of: String(s2.prefix(2))) {
-            return s1Semester < s2Semester
-        }
-
-        return false
-    }
-}
-
-extension MagazinesList {
-    typealias ResultsPublisher = Publishers.Zip<
-        Publishers.Map<OperationPublisher<GetFeaturedMagazinesQuery.Data>, MagazineFields>,
-        Publishers.Map<OperationPublisher<GetMagazinesBySemesterQuery.Data>, MagazineFields>
-        >
     
-    typealias SectionStates = (
-        featuredMagazines: MainView.TabState<[Magazine]>,
-        magazinesBySemester: MainView.TabState<[Magazine]>
-    )
-    
-    typealias SectionQueries = (
-        featuredMagazines: AnyCancellable?,
-        magazinesBySemester: AnyCancellable?
-    )
-
-    private static func format(semesterString: String) -> String {
-        let prefix = semesterString.prefix(2)
-        let suffix = semesterString.suffix(2)
-
-        var result = ""
-
-        switch prefix {
-        case "fa":
-            result = "Fall"
-        case "sp":
-            result = "Spring"
-        default:
-            break
-        }
-
-        return "\(result) 20\(suffix)"
-    }
 }

--- a/Volume/Views/WeeklyDebriefView.swift
+++ b/Volume/Views/WeeklyDebriefView.swift
@@ -52,18 +52,6 @@ struct WeeklyDebriefView: View {
                 StatisticView(image: .volume.bookmark, leftText: "bookmarked", number: weeklyDebrief.numBookmarkedArticles, rightText: "articles")
                 
                 HStack {
-                    Text("You were among the top ")
-                        .font(.newYorkRegular(size: 16)) +
-                    Text("10% ")
-                        .font(.newYorkMedium(size: 36))
-                        .foregroundColor(.volume.orange) +
-                    Text("active readers last week!")
-                        .font(.newYorkRegular(size: 16))
-                    
-                    Spacer()
-                }
-                
-                HStack {
                     Text("Keep up the volume! 📣")
                         .font(.newYorkRegular(size: 16))
                         .frame(alignment: .leading)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

This PR provides improvements and modifications for magazines.


## Changes Made

### Magazines List

- Refactored `MagazinesList` to support MVVM
    - Created a `ViewModel` class and separated logic from UI
- Users can now view magazines from “All semesters” (temporary limit of 15)
    - Wrote a GraphQL query for fetching all magazines
- Reversed the order displayed in the semester dropdown with the most recent at the top

### Weekly Debrief

- Removed the “top 10% active readers” on weekly debrief as requested

### Magazine Reader

- Added a `ProgressView` that will spin if a magazine is loading
- Fixed bug where sharing a magazine caused the app to crash

### Minor Changes

- Updated `Secrets.plist` for magazines



## Test Coverage

- Used different devices with varying screen sizes in Simulator to see if there were any UI issues
- In-depth playtesting to minimize any bugs that may be present



## Next Steps

- Fetching all magazines has a limit of 15 at this moment. Once we get more magazines, will need to implement pagination/infinite scrolling for magazines.
- Add magazines to weekly debrief.
- Creating a cache system for magazines may help with performance and prevent repeated downloads of PDFs.



## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>
  <summary>Weekly Debrief</summary>
  <img src="https://user-images.githubusercontent.com/75594943/226142954-17a5f25c-bcd7-4968-a994-a401edfaaf61.png">
</details>
<details>
  <summary>Magazines List</summary>
  <img src="https://user-images.githubusercontent.com/75594943/226143019-d321a3db-cede-43bd-b26f-a6de5dff3010.png">
</details>



