### PR TITLE
Vin/publications

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		2E6A7D5E29D9EFD6002F5250 /* ArticlesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6A7D5D29D9EFD6002F5250 /* ArticlesViewModel.swift */; };
 		2E6A7D6329DA39D3002F5250 /* BookmarksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6A7D6229DA39D3002F5250 /* BookmarksViewModel.swift */; };
 		2E6A7D6629DA46E6002F5250 /* ReadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6A7D6529DA46E6002F5250 /* ReadsViewModel.swift */; };
+		2E6A7D6A29DA893B002F5250 /* HamburgerMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6A7D6929DA893B002F5250 /* HamburgerMenuView.swift */; };
 		2EB5568829B9485700794423 /* MagsScrollbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568729B9485700794423 /* MagsScrollbarView.swift */; };
 		2EB5568C29B94A5600794423 /* PageIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568B29B94A5600794423 /* PageIndicatorView.swift */; };
 		331159D727D41C89003B0F06 /* Image+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331159D627D41C89003B0F06 /* Image+Extensions.swift */; };
@@ -139,6 +140,7 @@
 		2E6A7D5D29D9EFD6002F5250 /* ArticlesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticlesViewModel.swift; sourceTree = "<group>"; };
 		2E6A7D6229DA39D3002F5250 /* BookmarksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksViewModel.swift; sourceTree = "<group>"; };
 		2E6A7D6529DA46E6002F5250 /* ReadsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadsViewModel.swift; sourceTree = "<group>"; };
+		2E6A7D6929DA893B002F5250 /* HamburgerMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HamburgerMenuView.swift; sourceTree = "<group>"; };
 		2EB5568729B9485700794423 /* MagsScrollbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagsScrollbarView.swift; sourceTree = "<group>"; };
 		2EB5568B29B94A5600794423 /* PageIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageIndicatorView.swift; sourceTree = "<group>"; };
 		2ED344C7F76751CD56407579 /* Pods-Volume.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volume.debug.xcconfig"; path = "Target Support Files/Pods-Volume/Pods-Volume.debug.xcconfig"; sourceTree = "<group>"; };
@@ -436,6 +438,7 @@
 			children = (
 				060B738A256340580035E252 /* BubblePeriodText.swift */,
 				2E4B30DD29CCEE9B000D6AA6 /* HapticTouch.swift */,
+				2E6A7D6929DA893B002F5250 /* HamburgerMenuView.swift */,
 				7E416C312561D7870010D70B /* Header.swift */,
 				3392D71B2937BF4E005165F6 /* ReaderToolbarView.swift */,
 				7E49582C2612BD740015BE45 /* RefreshableScrollView.swift */,
@@ -665,6 +668,7 @@
 				7EC15D9F257767ED0053BA0B /* Publication.swift in Sources */,
 				95AC9DCF2637C120000B4BEE /* Main.swift in Sources */,
 				7E9E478C2629494D007E8E6C /* SettingsPage.swift in Sources */,
+				2E6A7D6A29DA893B002F5250 /* HamburgerMenuView.swift in Sources */,
 				922FE3032931C78B00E14911 /* SearchResultsList.swift in Sources */,
 				7EC15DA0257767ED0053BA0B /* FollowingPublicationRow.swift in Sources */,
 				2E6A7D5029D9E3D3002F5250 /* TrendingView.swift in Sources */,

--- a/Volume/Assets.xcassets/flyer.imageset/Contents.json
+++ b/Volume/Assets.xcassets/flyer.imageset/Contents.json
@@ -1,17 +1,17 @@
 {
   "images" : [
     {
-      "filename" : "vector.png",
+      "filename" : "flyer@1x.png",
       "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "filename" : "vector (1).png",
+      "filename" : "flyer@2x.png",
       "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "filename" : "Vector (2).png",
+      "filename" : "flyer@3x.png",
       "idiom" : "universal",
       "scale" : "3x"
     }

--- a/Volume/Supporting Views/HamburgerMenuView.swift
+++ b/Volume/Supporting Views/HamburgerMenuView.swift
@@ -1,0 +1,44 @@
+//
+//  HamburgerMenuView.swift
+//  Volume
+//
+//  Created by Vin Bui on 4/3/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+
+struct HamburgerMenuView: View {
+    
+    // MARK: - Constants
+    
+    private struct Constants {
+        static let hamburgerLineHeight: CGFloat = 1
+        static let hamburgerLineSpacing: CGFloat = 7
+        static let hamburgerLineWidth: CGFloat = 25
+        static let hamburgerPadding: CGFloat = 10
+    }
+    
+    // MARK: - UI
+    
+    var body: some View {
+        Group {
+            VStack(spacing: Constants.hamburgerLineSpacing) {
+                Rectangle()
+                    .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
+                Rectangle()
+                    .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
+                Rectangle()
+                    .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
+            }
+            .contentShape(Rectangle())
+        }
+        .padding(.init(
+            top: Constants.hamburgerPadding,
+            leading: Constants.hamburgerPadding,
+            bottom: Constants.hamburgerPadding,
+            trailing: Constants.hamburgerPadding
+        ))
+    }
+    
+}

--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -39,7 +39,7 @@ enum Message {
         case .noFollowingHome:
             return "Follow some student publications that you are interested in"
         case .noFollowingPublications:
-            return "Follow some below and we'll show them up here"
+            return "Follow some below and we'll display them here"
         case .upToDate:
             return "You've seen all new articles from the publications you're following."
         case .noSearchResults:

--- a/Volume/Views/MainView and Tabs/MainView.swift
+++ b/Volume/Views/MainView and Tabs/MainView.swift
@@ -84,59 +84,61 @@ struct MainView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .trailing) {
-                tabViewContainer
-                floatingTabBar
-                
+        NavigationView {
+            GeometryReader { geometry in
                 ZStack(alignment: .trailing) {
-                    Color.black.opacity(0.0001)
-                        .ignoresSafeArea(.all)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            withAnimation { showPublication.toggle() }
+                    tabViewContainer
+                    floatingTabBar
+                    
+                    ZStack(alignment: .trailing) {
+                        Color.black.opacity(0.0001)
+                            .ignoresSafeArea(.all)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                withAnimation { showPublication.toggle() }
+                            }
+                        
+                        Rectangle()
+                            .frame(width: geometry.size.width * 0.8)
+                            .shadow(radius: 10)
+                        
+                        PublicationList(showPublication: $showPublication)
+                            .frame(width: geometry.size.width * 0.8)
+                    }
+                    .offset(x: showPublication ? 0 : UIScreen.main.bounds.width)
+                    .animation(.spring(), value: showPublication)
+                }
+                .onAppear {
+                    SwiftUIAnnounce.presentAnnouncement { presented in
+                        if presented {
+                            AppDevAnalytics.log(VolumeEvent.announcementPresented.toEvent(.general))
                         }
-                    
-                    Rectangle()
-                        .frame(width: geometry.size.width * 0.8)
-                        .shadow(radius: 10)
-                    
-                    PublicationList(showPublication: $showPublication)
-                        .frame(width: geometry.size.width * 0.8)
-                }
-                .offset(x: showPublication ? 0 : UIScreen.main.bounds.width)
-                .animation(.spring(), value: showPublication)
-            }
-            .onAppear {
-                SwiftUIAnnounce.presentAnnouncement { presented in
-                    if presented {
-                        AppDevAnalytics.log(VolumeEvent.announcementPresented.toEvent(.general))
                     }
                 }
-            }
-            .onOpenURL { url in
-                guard url.isDeeplink else {
-                    return
-                }
+                .onOpenURL { url in
+                    guard url.isDeeplink else {
+                        return
+                    }
 
-                switch url.contentType {
-                case .article:
-                    if selectedTab != .reads {
-                        selectedTab = .reads
-                        UIApplication.shared.open(url)
+                    switch url.contentType {
+                    case .article:
+                        if selectedTab != .reads {
+                            selectedTab = .reads
+                            UIApplication.shared.open(url)
+                        }
+                    case .magazine:
+                        if selectedTab != .reads {
+                            selectedTab = .reads
+                            UIApplication.shared.open(url)
+                        }
+                    default:
+                        break
                     }
-                case .magazine:
-                    if selectedTab != .reads {
-                        selectedTab = .reads
-                        UIApplication.shared.open(url)
-                    }
-                default:
-                    break
                 }
-            }
-            .onChange(of: notifications.isWeeklyDebriefOpen) { isOpen in
-                if isOpen {
-                    selectedTab = .trending
+                .onChange(of: notifications.isWeeklyDebriefOpen) { isOpen in
+                    if isOpen {
+                        selectedTab = .trending
+                    }
                 }
             }
         }

--- a/Volume/Views/MainView and Tabs/MainView.swift
+++ b/Volume/Views/MainView and Tabs/MainView.swift
@@ -90,7 +90,7 @@ struct MainView: View {
                 floatingTabBar
                 
                 ZStack(alignment: .trailing) {
-                    Color.clear
+                    Color.black.opacity(0.0001)
                         .ignoresSafeArea(.all)
                         .contentShape(Rectangle())
                         .onTapGesture {

--- a/Volume/Views/MainView and Tabs/MainView.swift
+++ b/Volume/Views/MainView and Tabs/MainView.swift
@@ -143,6 +143,7 @@ struct MainView: View {
             }
         }
     }
+    
 }
 
 extension MainView {

--- a/Volume/Views/MainView and Tabs/ReadsView.swift
+++ b/Volume/Views/MainView and Tabs/ReadsView.swift
@@ -19,7 +19,7 @@ struct ReadsView: View {
         let navBarAppearance = UINavigationBarAppearance()
         navBarAppearance.configureWithTransparentBackground()
         navBarAppearance.backgroundColor = UIColor(Constants.backgroundColor)
-        
+
         UINavigationBar.appearance().standardAppearance = navBarAppearance
         UINavigationBar.appearance().compactAppearance = navBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance

--- a/Volume/Views/MainView and Tabs/ReadsView.swift
+++ b/Volume/Views/MainView and Tabs/ReadsView.swift
@@ -11,27 +11,27 @@ import SwiftUI
 struct ReadsView: View {
     
     // MARK: - Properties
-    @StateObject private var viewModel = ViewModel()
     
-    init() {
+    @Binding var showPublication: Bool
+    @StateObject private var viewModel = ViewModel()
+
+    let navBarAppearance: UINavigationBarAppearance = {
         let navBarAppearance = UINavigationBarAppearance()
         navBarAppearance.configureWithTransparentBackground()
         navBarAppearance.backgroundColor = UIColor(Constants.backgroundColor)
-
+        
         UINavigationBar.appearance().standardAppearance = navBarAppearance
         UINavigationBar.appearance().compactAppearance = navBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
-    }
+        
+        return navBarAppearance
+    }()
     
     // MARK: - Constants
     
     private struct Constants {
         static let articlesTabWidth: CGFloat = 80
         static let browserViewNavigationTitleKey: String = "BrowserView"
-        static let hamburgerLineHeight: CGFloat = 1
-        static let hamburgerLineSpacing: CGFloat = 7
-        static let hamburgerLineWidth: CGFloat = 25
-        static let hamburgerSidePadding: CGFloat = 30
         static let magazinesTabWidth: CGFloat = 106
         static let magazineNavigationTitleKey = "MagazineReaderView"
         static let searchTopPadding: CGFloat = 8
@@ -58,10 +58,16 @@ struct ReadsView: View {
                     
                     Spacer()
                     
-                    hamburgerMenu
+                    HamburgerMenuView()
                         .onTapGesture {
                             Haptics.shared.play(.light)
+                            withAnimation(.spring()) {
+                                showPublication.toggle()
+                            }
                         }
+                    
+                    Spacer()
+                    Spacer()
                 }
                 
                 scrollContent
@@ -101,19 +107,6 @@ struct ReadsView: View {
                 )
             ]
         )
-    }
-    
-    private var hamburgerMenu: some View {
-        VStack(spacing: Constants.hamburgerLineSpacing) {
-            Rectangle()
-                .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
-            Rectangle()
-                .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
-            Rectangle()
-                .frame(width: Constants.hamburgerLineWidth, height: Constants.hamburgerLineHeight)
-        }
-        .padding(.top)
-        .padding(.trailing, Constants.hamburgerSidePadding)
     }
     
     private var scrollContent: some View {

--- a/Volume/Views/Publications/PublicationList.swift
+++ b/Volume/Views/Publications/PublicationList.swift
@@ -86,7 +86,7 @@ struct PublicationList: View {
                     }
                 }
             } else {
-                VolumeMessage(message: .noFollowingPublications, largeFont: false, fullWidth: true)
+                VolumeMessage(image: Image.volume.pen, message: .noFollowingPublications, largeFont: false, fullWidth: true)
             }
         }
     }

--- a/Volume/Views/Publications/PublicationList.swift
+++ b/Volume/Views/Publications/PublicationList.swift
@@ -152,6 +152,7 @@ struct PublicationList: View {
                 fetch()
             }
     }
+    
 }
 
 extension PublicationList {

--- a/Volume/Views/Publications/PublicationList.swift
+++ b/Volume/Views/Publications/PublicationList.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct PublicationList: View {
     @State private var cancellableQuery: AnyCancellable?
+    @Binding var showPublication: Bool
     @State private var state: MainView.TabState<Results> = .loading
     @EnvironmentObject private var networkState: NetworkState
     @EnvironmentObject private var userData: UserData
@@ -145,18 +146,11 @@ struct PublicationList: View {
             }
             .disabled(state.isLoading)
             .padding(.top)
-            .background(Color.volume.backgroundGray)
-            .toolbar {
-                ToolbarItem(placement: ToolbarItemPlacement.navigationBarLeading) {
-                    BubblePeriodText("Publications")
-                        .font(.newYorkMedium(size: 28))
-                        .offset(y: 8)
-                }
-            }
+            .background(Color.white)
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
                 fetch()
-        }
+            }
     }
 }
 


### PR DESCRIPTION
## Overview
This PR adds a hamburger menu in the Reads page to display publications.

## Changes Made

### Hamburger Menu

- Created `HamburgerMenuView` in `SupportingViews/`
- Tapping on this menu slides the publications view into view with a spring animation
- Created a ZStack in order to place the publications view above the tab bar
- Tapping outside of the sidebar dismisses the view

### Minor Changes

- Changed no followed publications message as requested

## Test Coverage
- Used different devices with varying screen sizes in Simulator to see if there were any UI issues
- In-depth playtesting to minimize any bugs that may be present

## Next Steps
- May need to double check that scrolling works and everything is functional once backend is fixed.
- Note that the publications not loading is a backend issue.

## Screenshots
<details>
  <summary>Sidebar (publications not loading is a backend issue)</summary>
     <video src="https://user-images.githubusercontent.com/75594943/229665814-51c3eb9e-39af-4c82-a9cf-8f136f256a92.mp4" type="video/mp4">
</details>