### PR TITLE
Add today's flyers and empty state

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -988,7 +988,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1000,7 +1000,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1018,7 +1018,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1030,7 +1030,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -12,6 +12,10 @@ enum Message {
     case noBookmarkedArticles
     case noBookmarkedFlyers
     case noBookmarkedMagazines
+    case noFlyersPast
+    case noFlyersToday
+    case noFlyersUpcoming
+    case noFlyersWeekly
     case noFollowingHome
     case noFollowingPublications
     case noSearchResults
@@ -28,6 +32,14 @@ enum Message {
             return "You're up to date!"
         case .upToDateFlyers:
             return "Are you an organization?"
+        case .noFlyersPast:
+            return "No past flyers"
+        case .noFlyersToday:
+            return "No flyers today"
+        case .noFlyersUpcoming:
+            return "No upcoming flyers for this category"
+        case .noFlyersWeekly:
+            return "No flyers this week"
         }
     }
 
@@ -47,7 +59,7 @@ enum Message {
             return "You've seen all new articles from the publications you're following."
         case .noSearchResults:
             return "We could not find any results."
-        case .upToDateFlyers:
+        case .upToDateFlyers, .noFlyersPast, .noFlyersToday, .noFlyersUpcoming, .noFlyersWeekly:
             return "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com."
         }
     }
@@ -66,8 +78,12 @@ struct VolumeMessage: View {
             VStack(spacing: 10) {
                 image
                     .foregroundColor(.volume.orange)
+                
                 Text(message.title)
                     .font(.newYorkMedium(size: largeFont ? 24 : 18))
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                
                 Text(message.subtitle)
                     .font(.helveticaRegular(size: 12))
                     .multilineTextAlignment(.center)

--- a/Volume/View Models/FlyersViewModel.swift
+++ b/Volume/View Models/FlyersViewModel.swift
@@ -16,6 +16,7 @@ extension FlyersView {
         // MARK: - Properties
         
         @Published var allCategories: [OrganizationType]? = nil
+        @Published var dailyFlyers: [Flyer]? = nil
         @Published var hasMorePast: Bool = true
         @Published var hasMoreUpcoming: Bool = true
         @Published var pastFlyers: [Flyer]? = nil
@@ -49,6 +50,7 @@ extension FlyersView {
         
         func fetchContent() async {
             allCategories == nil ? fetchCategories() : nil
+            dailyFlyers == nil ? fetchDaily() : nil
             thisWeekFlyers == nil ? fetchThisWeek() : nil
             upcomingFlyers == nil ? await fetchUpcoming() : nil
             pastFlyers == nil ? fetchPast() : nil
@@ -58,6 +60,7 @@ extension FlyersView {
             Network.shared.clearCache()
             queryBag.removeAll()
             
+            dailyFlyers = nil
             thisWeekFlyers = nil
             upcomingFlyers = nil
             pastFlyers = nil
@@ -106,6 +109,30 @@ extension FlyersView {
         }
         
         // MARK: - Private Requests
+        
+        private func fetchDaily() {
+            // TODO: Fetch flyers under "Today"
+            guard let url = URL(string: "\(Secrets.cboardEndpoint)/flyers/daily/") else { return }
+            
+            URLSession.shared.dataTaskPublisher(for: url)
+                .subscribe(on: DispatchQueue.global(qos: .background))
+                .receive(on: DispatchQueue.main)
+                .tryMap { data, response in
+                    guard let response = response as? HTTPURLResponse,
+                          response.statusCode >= 200 && response.statusCode < 300 else {
+                        throw URLError(.badServerResponse)
+                    }
+                    return data
+                }
+                .decode(type: [Flyer].self, decoder: JSONDecoder.flyersDecoder)
+                .sink { completion in
+                    print("Fetching daily flyers: \(completion)")
+                } receiveValue: { [weak self] flyers in
+                    let sortedFlyers = self?.sortFlyersByDateAsc(for: flyers)
+                    self?.dailyFlyers = sortedFlyers
+                }
+                .store(in: &queryBag)
+        }
         
         private func fetchThisWeek() {
             // TODO: Fetch flyers under "This Week"

--- a/Volume/View Models/FlyersViewModel.swift
+++ b/Volume/View Models/FlyersViewModel.swift
@@ -80,7 +80,7 @@ extension FlyersView {
                 .receive(on: DispatchQueue.main)
                 .tryMap { data, response in
                     guard let response = response as? HTTPURLResponse,
-                          response.statusCode >= 200 && response.statusCode < 300 else {
+                          200..<300 ~= response.statusCode else {
                         throw URLError(.badServerResponse)
                     }
                     return data
@@ -143,7 +143,7 @@ extension FlyersView {
                 .receive(on: DispatchQueue.main)
                 .tryMap { data, response in
                     guard let response = response as? HTTPURLResponse,
-                          response.statusCode >= 200 && response.statusCode < 300 else {
+                          200..<300 ~= response.statusCode else {
                         throw URLError(.badServerResponse)
                     }
                     return data
@@ -172,7 +172,7 @@ extension FlyersView {
                 .receive(on: DispatchQueue.main)
                 .tryMap { data, response in
                     guard let response = response as? HTTPURLResponse,
-                          response.statusCode >= 200 && response.statusCode < 300 else {
+                          200..<300 ~= response.statusCode else {
                         throw URLError(.badServerResponse)
                     }
                     return data

--- a/Volume/Views/Flyers/FlyerCellThisWeek.swift
+++ b/Volume/Views/Flyers/FlyerCellThisWeek.swift
@@ -12,7 +12,9 @@ struct FlyerCellThisWeek: View {
     
     // MARK: - Properties
     
+    let cellSize: CGSize
     let flyer: Flyer
+    let imageSize: CGSize
     @StateObject var urlImageModel: URLImageModel
     
     // MARK: - Constants
@@ -23,11 +25,7 @@ struct FlyerCellThisWeek: View {
         static let categoryFont: Font = .helveticaRegular(size: 10)
         static let categoryHorizontalPadding: CGFloat = 16
         static let categoryVerticalPadding: CGFloat = 4
-        static let cellHeight: CGFloat = 344
-        static let cellWidth: CGFloat = 256
         static let dateFont: Font = .helveticaRegular(size: 12)
-        static let imageHeight: CGFloat = 256
-        static let imageWidth: CGFloat = 256
         static let locationFont: Font = .helveticaRegular(size: 12)
         static let organizationNameFont: Font = .newYorkMedium(size: 10)
         static let spacing: CGFloat = 4
@@ -53,7 +51,7 @@ struct FlyerCellThisWeek: View {
                 flyerDate
                 flyerLocation
             }
-            .frame(width: Constants.cellWidth, height: Constants.cellHeight)
+            .frame(width: cellSize.width, height: cellSize.height)
         }
         .buttonStyle(EmptyButtonStyle())
     }
@@ -66,7 +64,7 @@ struct FlyerCellThisWeek: View {
             flyerDate
             flyerLocation
         }
-        .frame(width: Constants.cellWidth, height: Constants.cellHeight)
+        .frame(width: cellSize.width, height: cellSize.height)
     }
     
     private var imageFrame: some View {
@@ -79,7 +77,7 @@ struct FlyerCellThisWeek: View {
                     Image(uiImage: urlImageModel.image ?? UIImage())
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: Constants.imageWidth, height: Constants.imageHeight)
+                        .frame(width: imageSize.width, height: imageSize.height)
                 }
             } else {
                 SkeletonView()
@@ -101,7 +99,7 @@ struct FlyerCellThisWeek: View {
                 .clipShape(RoundedRectangle(cornerRadius: Constants.categoryCornerRadius))
                 .padding([.top, .leading], 8)
         }
-        .frame(width: Constants.imageWidth, height: Constants.imageHeight)
+        .frame(width: imageSize.width, height: imageSize.height)
     }
     
     private var bookmarkButton: some View {
@@ -190,10 +188,14 @@ struct FlyerCellThisWeek: View {
 extension FlyerCellThisWeek {
     
     struct Skeleton: View {
+        
+        let cellSize: CGSize
+        let imageSize: CGSize
+        
         var body: some View {
             VStack(alignment: .leading) {
                 SkeletonView()
-                    .frame(width: Constants.imageWidth, height: Constants.imageHeight)
+                    .frame(width: imageSize.width, height: imageSize.height)
 
                 SkeletonView()
                     .frame(width: 130, height: 15)
@@ -207,7 +209,7 @@ extension FlyerCellThisWeek {
                 SkeletonView()
                     .frame(width: 100, height: 15)
             }
-            .frame(width: Constants.cellWidth, height: Constants.cellHeight)
+            .frame(width: cellSize.width, height: cellSize.height)
         }
     }
     


### PR DESCRIPTION
## Overview
This PR adds daily flyers as well as the empty state for flyers.

## Changes Made

### Flyers

- Added a section for daily flyers
- Added the empty state for flyers

## Test Coverage
- Used different devices with varying screen sizes in Simulator to see if there were any UI issues
- In-depth playtesting to minimize any bugs that may be present

## Screenshots
<details>
  <summary>Today Section</summary>
  <video src="https://user-images.githubusercontent.com/75594943/234763199-f82fd994-5775-49bc-b61b-79eb69b6aea1.mp4" type="video/mp4">
</details>

<!-- use the following for images -->
<details>
  <summary>Empty State</summary>
  <img src="https://user-images.githubusercontent.com/75594943/234763086-7e33de52-9ee0-4609-a6dd-3447b1c98ff6.png" width="300px" height="auto"></td>
</details>