### PR TITLE
Update upcoming section of cboard to scroll vertically

### DIFF
--- a/Volume/Views/MainView and Tabs/FlyersView.swift
+++ b/Volume/Views/MainView and Tabs/FlyersView.swift
@@ -29,7 +29,6 @@ struct FlyersView: View {
         static let rowVerticalPadding: CGFloat = 6
         static let spacing: CGFloat = 16
         static let titleFont: Font = .newYorkMedium(size: 28)
-        static let upcomingSectionHeight: CGFloat = 308
         static let volumeMessagePadding: CGFloat = 20
         static let weeklyButtonSize: CGSize = CGSize(width: 15, height: 15)
         static let weeklyCellSize: CGSize = CGSize(width: 256, height: 350)

--- a/Volume/Views/MainView and Tabs/FlyersView.swift
+++ b/Volume/Views/MainView and Tabs/FlyersView.swift
@@ -169,29 +169,27 @@ struct FlyersView: View {
                 flyers.isEmpty ? emptyMessage(section: .upcoming) : nil
             }
             
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHGrid(rows: Constants.gridRows, spacing: Constants.spacing) {
-                    switch viewModel.upcomingFlyers {
-                    case .none:
-                        ForEach(0..<6) { _ in
-                            FlyerCellUpcoming.Skeleton()
-                        }
-                    case .some(let flyers):
-                        ForEach(flyers) { flyer in
-                            if let urlString = flyer.imageUrl?.absoluteString {
-                                FlyerCellUpcoming(
-                                    flyer: flyer,
-                                    navigationSource: .flyersTab,
-                                    urlImageModel: URLImageModel(urlString: urlString),
-                                    viewModel: viewModel
-                                )
-                            }
+            // TODO: Update FlyerCellUpcoming after user research
+            Group {
+                switch viewModel.upcomingFlyers {
+                case .none:
+                    FlyerCellPast.Skeleton()
+                        .padding(.bottom, Constants.spacing)
+                    FlyerCellPast.Skeleton()
+                case .some(let flyers):
+                    ForEach(flyers) { flyer in
+                        if let urlString = flyer.imageUrl?.absoluteString {
+                            FlyerCellPast(
+                                flyer: flyer,
+                                navigationSource: .flyersTab,
+                                urlImageModel: URLImageModel(urlString: urlString),
+                                viewModel: viewModel
+                            )
                         }
                     }
                 }
-                .padding(.horizontal, Constants.listHorizontalPadding)
-                .frame(height: viewModel.upcomingFlyers?.isEmpty ?? false ? 0 : Constants.upcomingSectionHeight)
             }
+            .padding(.horizontal, Constants.listHorizontalPadding)
             .environment(\EnvironmentValues.refresh as! WritableKeyPath<EnvironmentValues, RefreshAction?>, nil)
         } header: {
             upcomingHeader


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Quick fix to change Upcoming Section to scroll vertically because the upcoming flyer cells were too small in the original horizontal scroll view

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- Use `FlyerCellPast` to display upcoming flyers in `upcomingSection` of `FlyersView.swift`
- Remove horizontal scroll view from `upcomingSection`

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Playtested in simulator


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
- Update `FlyerCellUpcoming` once we receive finalized designs based on user research and replace `FlyerCellPast` in `upcomingSection`
- Update layout of `upcomingSection` again if necessary

## Screenshots
| Before | After |
| - | - |
|<img src="https://github.com/cuappdev/volume-ios/assets/57200368/333043d4-b38e-4d64-adc6-fa8b4e4dfd7b" width="250">|<img src="https://github.com/cuappdev/volume-ios/assets/57200368/98767322-b327-49a0-a806-3199fe28500e" width="250">|
