### PR TITLE
Minor Bug Fixes

### DIFF
--- a/Volume/Extensions/Date+Extension.swift
+++ b/Volume/Extensions/Date+Extension.swift
@@ -44,10 +44,10 @@ extension Date {
         return formatter.string(from: self)
     }
     
-    /// This `Date` in the format "MMM d yy h:mm a". For example, April 11 2023 at 5:00 PM is Apr 11 23 5:00 PM
-    var flyerDateTimeString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d yy h:mm a"
+    /// This `Date` in UTC ISO 8601 format
+    var flyerUTCISOString: String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = NSTimeZone(abbreviation: "UTC") as? TimeZone
         return formatter.string(from: self)
     }
     

--- a/Volume/Supporting/AboutConstants.swift
+++ b/Volume/Supporting/AboutConstants.swift
@@ -18,10 +18,12 @@ struct AboutConstants {
             subteams: [
                 .podLead("Jennifer Gu"),
                 .ios([
-                    "Vin Bui"
+                    "Vin Bui",
+                    "Jennifer Gu"
                 ]),
                 .backend([
-                    "Isaac Han"
+                    "Cindy Liang",
+                    "Aayush Agnihotri"
                 ]),
                 .android([
                     "Zach Seidner"
@@ -30,7 +32,8 @@ struct AboutConstants {
                     "Amy Ge"
                 ]),
                 .marketing([
-                    "Jane Lee"
+                    "Jane Lee",
+                    "Candy Wu"
                 ])
             ]
         ),

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -12,6 +12,7 @@ import SwiftUI
 import UserNotifications
 
 class Notifications: NSObject, ObservableObject {
+    
     static let shared = Notifications()
     private let center = UNUserNotificationCenter.current()
     let firebaseMessaging = Messaging.messaging()
@@ -80,24 +81,30 @@ class Notifications: NSObject, ObservableObject {
         guard let url = URL(string: "\(Secrets.openArticleUrl)\(id)") else { return }
         UIApplication.shared.open(url)
     }
+    
 }
 
 extension Notifications: UNUserNotificationCenterDelegate {
+    
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         // App is running in the background, user taps notification
         handlePushNotification(userInfo: response.notification.request.content.userInfo)
         completionHandler()
     }
+    
 }
 
 extension Notifications {
+    
     private enum NotificationType: String {
         case newArticle = "new_article"
         case weeklyDebrief = "weekly_debrief"
     }
+    
 }
 
 extension Notifications: MessagingDelegate {
+    
     @MainActor func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
             #if DEBUG
@@ -114,4 +121,5 @@ extension Notifications: MessagingDelegate {
         let tokenDict = ["token": fcmToken ?? ""]
         NotificationCenter.default.post(name: Notification.Name("FCMToken"), object: nil,userInfo: tokenDict)
     }
+    
 }

--- a/Volume/Supporting/Notifications.swift
+++ b/Volume/Supporting/Notifications.swift
@@ -98,7 +98,7 @@ extension Notifications {
 }
 
 extension Notifications: MessagingDelegate {
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    @MainActor func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         if let fcmToken = fcmToken {
             #if DEBUG
             print("Firebase Messaging registration token: \(fcmToken)")

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 import SwiftUI
 
+@MainActor
 class UserData: ObservableObject {
 
     static let shared = UserData()
@@ -32,80 +33,62 @@ class UserData: ObservableObject {
     /// wipe the cache.
     @Published var shoutoutsCache: [String: Int] = [:] {
         willSet {
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
 
     @Published private(set) var savedArticleIDs: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: articlesKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
 
     @Published private(set) var followedPublicationSlugs: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: publicationsKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
 
     @Published private var articleShoutoutsCounter: [String: Int] = [:] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: articleShoutoutsKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
     
     @Published var magazineShoutoutsCache: [String: Int] = [:] {
         willSet {
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
     
     @Published private(set) var savedMagazineIDs: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: magazinesKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
 
     @Published private var magazineShoutoutsCounter: [String: Int] = [:] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: magazineShoutoutsKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
     
     @Published var recentSearchQueries: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: recentSearchesKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
     
     @Published private(set) var savedFlyerIDs: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: flyersKey)
-            DispatchQueue.main.async {
-                self.objectWillChange.send()
-            }
+            self.objectWillChange.send()
         }
     }
     
@@ -236,9 +219,11 @@ class UserData: ObservableObject {
     }
     
     func addRecentSearchQueries(_ query: String) {
+        let maxSearches: Int = 20
+        
         recentSearchQueries = recentSearchQueries.filter { $0 != query }
         recentSearchQueries.insert(query, at: 0)
-        if recentSearchQueries.count > 10 { recentSearchQueries.removeLast() }
+        if recentSearchQueries.count > maxSearches { recentSearchQueries.removeLast() }
     }
     
     func removeRecentSearchQueries(_ query: String) {
@@ -259,7 +244,6 @@ class UserData: ObservableObject {
         
         if isSaved {
             cancellables[.bookmarkArticle(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid))
-                .receive(on: DispatchQueue.main)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
@@ -272,9 +256,7 @@ class UserData: ObservableObject {
                 }
         } else {
             requestInProgress = false
-            DispatchQueue.main.async {
-                self.savedArticleIDs.removeAll(where: { $0 == article.id })
-            }
+            self.savedArticleIDs.removeAll(where: { $0 == article.id })
         }
     }
 
@@ -304,9 +286,7 @@ class UserData: ObservableObject {
                 }
         } else {
             requestInProgress = false
-            DispatchQueue.main.async {
-                self.savedMagazineIDs.removeAll(where: { $0 == magazine.id })
-            }
+            self.savedMagazineIDs.removeAll(where: { $0 == magazine.id })
         }
     }
     
@@ -336,9 +316,7 @@ class UserData: ObservableObject {
                 }
         } else {
             requestInProgress = false
-            DispatchQueue.main.async {
-                self.savedFlyerIDs.removeAll(where: { $0 == flyer.id })
-            }
+            self.savedFlyerIDs.removeAll(where: { $0 == flyer.id })
         }
     }
 
@@ -348,14 +326,12 @@ class UserData: ObservableObject {
         
         guard let uuid = uuid else {
             // User has not finished onboarding
-            DispatchQueue.main.async {
-                if isFollowed {
-                    if !self.followedPublicationSlugs.contains(publication.slug) {
-                        self.followedPublicationSlugs.insert(publication.slug, at: 0)
-                    }
-                } else {
-                    self.followedPublicationSlugs.removeAll(where: { $0 == publication.slug })
+            if isFollowed {
+                if !self.followedPublicationSlugs.contains(publication.slug) {
+                    self.followedPublicationSlugs.insert(publication.slug, at: 0)
                 }
+            } else {
+                self.followedPublicationSlugs.removeAll(where: { $0 == publication.slug })
             }
             requestInProgress = false
             return
@@ -364,7 +340,6 @@ class UserData: ObservableObject {
         if isFollowed {
             let followMutation = FollowPublicationMutation(slug: publication.slug, uuid: uuid)
             cancellables[.follow(publication)] = Network.shared.publisher(for: followMutation)
-                .receive(on: DispatchQueue.main)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: FollowPublicationMutation failed on UserData: \(error.localizedDescription)")
@@ -379,7 +354,6 @@ class UserData: ObservableObject {
         } else {
             let unfollowMutation = UnfollowPublicationMutation(slug: publication.slug, uuid: uuid)
             cancellables[.unfollow(publication)] = Network.shared.publisher(for: unfollowMutation)
-                .receive(on: DispatchQueue.main)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: UnfollowPublicationMutation failed on UserData: \(error.localizedDescription)")

--- a/Volume/View Models/FlyersViewModel.swift
+++ b/Volume/View Models/FlyersViewModel.swift
@@ -76,7 +76,7 @@ extension FlyersView {
         }
         
         func fetchUpcoming() async {
-            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerDateTimeString))
+            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerUTCISOString))
                 .map { $0.flyers.map(\.fragments.flyerFields) }
                 .sink { [weak self] completion in
                     self?.networkState?.handleCompletion(screen: .flyers, completion)
@@ -114,7 +114,7 @@ extension FlyersView {
         // MARK: - Private Requests
         
         private func fetchDaily() async {
-            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerDateTimeString))
+            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerUTCISOString))
                 .map { $0.flyers.map(\.fragments.flyerFields) }
                 .sink { [weak self] completion in
                     self?.networkState?.handleCompletion(screen: .flyers, completion)
@@ -127,7 +127,7 @@ extension FlyersView {
         }
         
         private func fetchThisWeek() async {
-            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerDateTimeString))
+            Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerUTCISOString))
                 .map { $0.flyers.map(\.fragments.flyerFields) }
                 .sink { [weak self] completion in
                     self?.networkState?.handleCompletion(screen: .flyers, completion)
@@ -151,7 +151,7 @@ extension FlyersView {
             Network.shared.publisher(
                 for: GetFlyersBeforeDateQuery(
                     limit: Constants.pastFlyersLimit,
-                    before: Date().flyerDateTimeString)
+                    before: Date().flyerUTCISOString)
                 )
                 .map { $0.flyers.map(\.fragments.flyerFields) }
                 .sink { [weak self] completion in

--- a/Volume/Views/Flyers/FlyersSupporting.swift
+++ b/Volume/Views/Flyers/FlyersSupporting.swift
@@ -19,21 +19,30 @@ struct FlyersBookmark: View {
     let navigationSource: NavigationSource
     
     @State private var bookmarkRequestInProgress: Bool = false
+    @State private var isFlyerSaved: Bool = false
     @EnvironmentObject private var userData: UserData
     
     // MARK: - UI
     
     var body: some View {
-        if isPast {
-            pastBookmark
-        } else {
-            upcomingBookmark
+        Group {
+            if isPast {
+                pastBookmark
+            } else {
+                upcomingBookmark
+            }
+        }
+        .onAppear {
+            isFlyerSaved = userData.isFlyerSaved(flyer)
+        }
+        .onChange(of: userData.isFlyerSaved(flyer)) { saved in
+            isFlyerSaved = saved
         }
     }
     
     @ViewBuilder
     private var pastBookmark: some View {
-        if userData.isFlyerSaved(flyer) {
+        if isFlyerSaved {
             Image.volume.bookmarkFilled
                 .resizable()
                 .scaledToFit()
@@ -65,7 +74,7 @@ struct FlyersBookmark: View {
             Haptics.shared.play(.light)
             toggleSaved(for: flyer)
         } label: {
-            if userData.isFlyerSaved(flyer) {
+            if isFlyerSaved {
                 Image.volume.bookmarkFilled
                     .resizable()
                     .scaledToFit()
@@ -91,6 +100,7 @@ struct FlyersBookmark: View {
     
     private func toggleSaved(for flyer: Flyer) {
         bookmarkRequestInProgress = true
+        isFlyerSaved.toggle()
         userData.toggleFlyerSaved(flyer, $bookmarkRequestInProgress)
         AppDevAnalytics.log(
             VolumeEvent.bookmarkFlyer.toEvent(.flyer, value: flyer.id, navigationSource: navigationSource)

--- a/Volume/Views/Onboarding/OnboardingFlyersView.swift
+++ b/Volume/Views/Onboarding/OnboardingFlyersView.swift
@@ -68,7 +68,7 @@ struct OnboardingFlyersView: View {
     }
     
     private func fetchUpcoming() async {
-        cancellableQuery = Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerDateTimeString))
+        cancellableQuery = Network.shared.publisher(for: GetFlyersAfterDateQuery(since: Date().flyerUTCISOString))
             .map { $0.flyers.map(\.fragments.flyerFields) }
             .sink { completion in
                 if case let .failure(error) = completion {

--- a/Volume/Views/Search/SearchDropdownView.swift
+++ b/Volume/Views/Search/SearchDropdownView.swift
@@ -9,14 +9,19 @@
 import SwiftUI
 
 struct SearchDropdownView: View {
+    
+    // MARK: - Properties
+    
     @Environment(\.presentationMode) var presentationMode
-    @EnvironmentObject private var userData: UserData
     @Binding var searchState: SearchView.SearchState
     @Binding var searchText: String
+    @EnvironmentObject private var userData: UserData
     
     private var suggestedSearchQueries: [String] {
         userData.recentSearchQueries
     }
+    
+    // MARK: - Constants
     
     private struct Constants {
         static let animationDuration: CGFloat = 0.1
@@ -25,38 +30,46 @@ struct SearchDropdownView: View {
         static let suggestedSearchHeader: String = "Recent Searches"
     }
     
+    // MARK: - UI
+    
     var body: some View {
-        VStack(alignment: .leading) {
-            if suggestedSearchQueries.count > 0 {
-                Header(Constants.suggestedSearchHeader)
-            }
-            VStack(alignment: .leading, spacing: Constants.searchQueryTextPadding) {
-                ForEach(suggestedSearchQueries, id: \.self) { query in
-                    HStack {
-                        Text(query)
-                            .font(.helveticaNeueMedium(size: Constants.searchQueryTextSize))
-                            .onTapGesture {
-                                withAnimation(.linear(duration: Constants.animationDuration)) {
-                                    userData.addRecentSearchQueries(query)
-                                    searchText = query
-                                    searchState = .results
-                                }
-                            }
-                        
-                        Spacer()
-
-                        Text("✗")
-                            .onTapGesture {
-                                withAnimation(.linear(duration: Constants.animationDuration)) {
-                                    userData.removeRecentSearchQueries(query)
-                                }
-                            }
+        ScrollView(showsIndicators: false) {
+            LazyVStack(alignment: .leading) {
+                suggestedSearchQueries.count > 0 ? Header(Constants.suggestedSearchHeader) : nil
+                
+                Group {
+                    ForEach(suggestedSearchQueries, id: \.self) { query in
+                        searchRow(query)
                     }
                 }
+                .padding(.bottom, Constants.searchQueryTextPadding)
             }
+            
+            Spacer()
         }
-        
-        Spacer()
+    }
+    
+    private func searchRow(_ query: String) -> some View {
+        HStack {
+            Text(query)
+                .font(.helveticaNeueMedium(size: Constants.searchQueryTextSize))
+                .onTapGesture {
+                    withAnimation(.linear(duration: Constants.animationDuration)) {
+                        userData.addRecentSearchQueries(query)
+                        searchText = query
+                        searchState = .results
+                    }
+                }
+            
+            Spacer()
+            
+            Text("✗")
+                .onTapGesture {
+                    withAnimation(.linear(duration: Constants.animationDuration)) {
+                        userData.removeRecentSearchQueries(query)
+                    }
+                }
+        }
     }
     
 }


### PR DESCRIPTION
## Overview
Fixed a couple of bugs as well as performance improvements to prepare for the new upload Flyer page.

## Changes Made

### Search

- Increased the number of recent searches from 10 → 20.
    - Ideally, this value should be factored out into a `Constants` struct, but because the entire `UserData` class does not have this yet, I just created a local variable (`maxSearches: Int`) in the function to make it a bit more clear.
- Added vertical scrolling for recent searches. This addresses Zach’s comment about the entire search view getting shifted up with many recent searches. Not only that but it improves the user experience and is a common trend we see in many apps.
- Refactored the code to make it a lot easier to read.

### UserData

- Removed `DispatchQueue` blocks and shifted to the `@MainActor` attribute.
    - Because all of these state changes should happen on the main thread, it is very tedious to add a `DispatchQueue.main` to every single call. By migrating to this new concurrency system introduced in Swift 5.5, it will eliminate the need for us to manually dispatch our UI updates on the main queue. This also works very well with SwiftUI as seen in the ViewModel classes that I’ve created in the codebase.

### Other Changes

- Updated the Fall 2023 roster.
- Made flyer bookmarking a ***bit*** more smooth. The UI still freezes but only for a split second. The issue seems to have something to do with concurrency in `UserData` but not a huge priority at this moment.
- Fixed the time zone issue where Flyers were not queries properly (i.e. Flyers were shown as upcoming when they weren’t).
    - Created a `Date` extension to convert a `Date` object to a UTC ISO8601 String.

## Test Coverage
- To test for the UI changes with search, I made sure that the keyboard was enabled to simulate the user’s perspective. I also tested on various phone sizes (iPhone 8, 14, 14 Pro, and 14 Pro Max) to ensure that these UI changes are responsive.
- As for the other changes I made, I tested every single button (bookmarking, shoutout, following, etc.) to ensure that there isn’t any significant change.
    - I did notice that the UI does freeze for a split second whenever you click on these buttons. This was already an issue before, when we had the original `DispatchQueue` blocks. Not a high priority right now, but will look into it when I get the chance.
- Tested the flyers query with my local database for edge cases. Everything seems to be working just fine.

## Next Steps
- Look into making it extremely smooth (with no freezing) when bookmarking, shouting out, etc.
- Look into the issue where loading a magazine freezes. This is because the call to `PDFDocument` provided by `PDFKit` is ran on the main thread. Using a `[DispatchQueue.global](http://DispatchQueue.global)` block to run it on the background thread doesn’t work because we are changing an `@State` property in a Sendable closure. Will look into this a bit more, but not a huge priority right now.

## Screenshots
<details>
  <summary>Search</summary>
  <table>
	  <tr>
	     <td>Before</td>
	     <td>After</td>
	  </tr>
  <tr>
    <td><img src="https://github.com/cuappdev/volume-ios/assets/75594943/8e360478-0f58-4f03-b1ea-bf1ccbb9cab0" width="300px" height="auto"></td>
    <td><video src="https://github.com/cuappdev/volume-ios/assets/75594943/97af697e-f20d-4a0e-bcde-54bcc10c541f
" type="video/mp4"></td>
  </tr>
 </table>
</details>