### PR TITLE
Upload Flyer Multipart Form Data

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,7 @@ target 'Volume' do
   use_frameworks!
 
   # Pods for Volume
+  pod 'Alamofire'
   pod 'Apollo'
   pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/analytics-ios.git', :commit => '5d459c0475'
   pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - Alamofire (5.8.0)
   - Apollo (0.53.0):
     - Apollo/Core (= 0.53.0)
   - Apollo/Core (0.53.0)
@@ -96,6 +97,7 @@ PODS:
   - SwiftLint (0.53.0)
 
 DEPENDENCIES:
+  - Alamofire
   - Apollo
   - AppDevAnalytics (from `https://github.com/cuappdev/analytics-ios.git`, commit `5d459c0475`)
   - AppDevAnnouncements (from `https://github.com/cuappdev/appdev-announcements.git`)
@@ -107,6 +109,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - Alamofire
     - Apollo
     - Firebase
     - FirebaseAnalytics
@@ -142,6 +145,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/cuappdev/appdev-announcements.git
 
 SPEC CHECKSUMS:
+  Alamofire: 0e92e751b3e9e66d7982db43919d01f313b8eb91
   Apollo: 204819ea82022fbc59ad05056820df867f19bd02
   AppDevAnalytics: 994c1ca730d79fbe530ce06b7bbffd5d05deff80
   AppDevAnnouncements: e17a7f441fb0664583bb08e21dc709214d15b70f
@@ -163,6 +167,6 @@ SPEC CHECKSUMS:
   SDWebImageSwiftUI: 76c824afd24d896710e47f240755a31b80e056a0
   SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
 
-PODFILE CHECKSUM: ebac97803ecf8b32500a82053a8a33e45a2bc400
+PODFILE CHECKSUM: 29e5a1268dded9c09557327e9889513b2e18c020
 
 COCOAPODS: 1.12.1

--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -1068,7 +1068,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1080,7 +1080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1098,7 +1098,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1110,7 +1110,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.8;
+				MARKETING_VERSION = 1.3.9;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -15,7 +15,7 @@ import Foundation
 /// Provides an API to create Publishers that execute GraphQL requests and return responses via ApolloClient
 class Network {
     static let shared = Network()
-    private let apollo = ApolloClient(url: Secrets.endpoint)
+    private let apollo = ApolloClient(url: Secrets.endpointGraphQL)
 
     /// Create a Publisher using a GraphQLQuery
     func publisher<Query: GraphQLQuery>(for query: Query) -> OperationPublisher<Query.Data> {

--- a/Volume/Supporting/Secrets.swift
+++ b/Volume/Supporting/Secrets.swift
@@ -14,9 +14,11 @@ struct Secrets {
 
     // swiftlint:disable force_cast
     #if DEBUG
-    static let endpoint = URL(string: keyDict["graphql-endpoint-debug"] as! String)!
+    static let endpointServer = URL(string: keyDict["server-endpoint-debug"] as! String)!
+    static let endpointGraphQL = URL(string: keyDict["graphql-endpoint-debug"] as! String)!
     #else
-    static let endpoint = URL(string: keyDict["graphql-endpoint-production"] as! String)!
+    static let endpointServer = URL(string: keyDict["server-endpoint-production"] as! String)!
+    static let endpointGraphQL = URL(string: keyDict["graphql-endpoint-production"] as! String)!
     #endif
 
     static let announcementsCommonPath = Secrets.keyDict["announcements-common-path"] as! String
@@ -24,7 +26,6 @@ struct Secrets {
     static let announcementsPath = Secrets.keyDict["announcements-path"] as! String
     static let announcementsScheme = Secrets.keyDict["announcements-scheme"] as! String
     static let appdevWebsite = Secrets.keyDict["appdev-website"] as! String
-    static let cboardEndpoint = Secrets.keyDict["cboard-endpoint-temp"] as! String
     static let feedbackForm = Secrets.keyDict["feedback-form"] as! String
     static let openArticleUrl = Secrets.keyDict["openarticle-url"] as! String
     static let openMagazineUrl = Secrets.keyDict["openmagazine-url"] as! String

--- a/Volume/View Models/OrgsLoginViewModel.swift
+++ b/Volume/View Models/OrgsLoginViewModel.swift
@@ -47,6 +47,7 @@ extension OrgsLoginView {
         func authenticate(accessCode: String, slug: String) async {
             organization = nil // Reset
             showSpinner = true
+            buttonEnabled = false
 
             Network.shared.publisher(for: CheckAccessCodeQuery(accessCode: accessCode, slug: slug))
                 .compactMap { $0.organization?.fragments.organizationFields }
@@ -57,6 +58,7 @@ extension OrgsLoginView {
                         self?.showErrorMessage = true
                         self?.isAuthenticated = false
                         self?.showSpinner = false
+                        self?.buttonEnabled = true
                     default:
                         break
                     }
@@ -65,6 +67,7 @@ extension OrgsLoginView {
                     self?.showErrorMessage = false
                     self?.isAuthenticated = true
                     self?.showSpinner = false
+                    self?.buttonEnabled = true
 
                     // Save/unsave login
                     if let self = self {

--- a/Volume/Views/Orgs Login/FlyerUploadView.swift
+++ b/Volume/Views/Orgs Login/FlyerUploadView.swift
@@ -388,7 +388,7 @@ struct FlyerUploadView: View {
                     Text(success ? "Flyer Published!" : "Oh no, something went wrong.")
                         .font(.newYorkMedium(size: 20))
 
-                    Text(success ? "Thank you for using Volume." : "Please try again later.")
+                    Text(success ? "Thank you for using Volume." : "Please try again with a smaller image size.")
                         .font(.helveticaRegular(size: 14))
                         .foregroundColor(Color.volume.lightGray)
                 }

--- a/Volume/Views/Orgs Login/FlyerUploadView.swift
+++ b/Volume/Views/Orgs Login/FlyerUploadView.swift
@@ -388,7 +388,7 @@ struct FlyerUploadView: View {
                     Text(success ? "Flyer Published!" : "Oh no, something went wrong.")
                         .font(.newYorkMedium(size: 20))
 
-                    Text(success ? "Thank you for using Volume." : "Please try again with a smaller image size.")
+                    Text(success ? "Thank you for using Volume." : "Please reduce the image file size and try again.")
                         .font(.helveticaRegular(size: 14))
                         .foregroundColor(Color.volume.lightGray)
                 }


### PR DESCRIPTION
## Overview

Rewrote the upload flyer backend call to use the new HTTP form data request instead of GraphQL mutations.

## Changes Made

- Installed Alamofire **(pronounced ”AH LUH MO FIRE”).**
- Updated our secrets to include the new endpoint.
- Used Alamofire to create a POST request that takes in multipart form data instead of a GraphQL mutation.
- Fixed a potential issue where users were able to authenticate twice by disabling the button until the network request is complete.
- Changed the error message from “Please try again later.” to “Please try again with a smaller image size.” to make it more clear.
    - Most of the time, the issue is with the image size so it’s fine to have a generic message like so.
- Updated version to 1.3.9 and build 30.

## Test Coverage

Tested with various image sizes from 100kb to 24mb. Everything seems to work fine and images that are too large will have the proper error message.

## Next Steps

Implement the organization flyer view page as well as editing and deleting flyer.

## Screenshots

These images are around 2mb which should be more than enough.
<img src="https://github.com/cuappdev/volume-ios/assets/75594943/fdb85f10-d981-4602-8558-36fc375fb4e0" width="300px" height="auto">