### PR TITLE
Org Edit and Delete Flyer

### DIFF
--- a/Volume/Extensions/Image+Extensions.swift
+++ b/Volume/Extensions/Image+Extensions.swift
@@ -44,6 +44,7 @@ extension Image {
         let share = Image("share")
         let shared = Image("shared")
         let shoutout = Image("shout-out")
+        let trash = Image(systemName: "trash")
         let underline = Image("underline")
         let upload = Image("upload")
         let weeklyDebriefCurves = Image("weekly-debrief-curves")

--- a/Volume/Networking/FlyerMutations.graphql
+++ b/Volume/Networking/FlyerMutations.graphql
@@ -15,3 +15,15 @@ mutation CreateFlyer($title: String!, $startDate: String!, $organizationID: Stri
     ...flyerFields
   }
 }
+
+mutation DeleteFlyer($id: String!) {
+  deleteFlyer(id: $id) {
+    id
+  }
+}
+
+mutation EditFlyer($id: String!, $title: String, $startDate: String, $location: String, $imageB64: String, $flyerURL: String, $endDate: String, $categorySlug: String) {
+  editFlyer(id: $id, title: $title, startDate: $startDate, location: $location, imageB64: $imageB64, flyerURL: $flyerURL, endDate: $endDate, categorySlug: $categorySlug) {
+    ...flyerFields
+  }
+}

--- a/Volume/View Models/FlyerUploadViewModel.swift
+++ b/Volume/View Models/FlyerUploadViewModel.swift
@@ -60,6 +60,7 @@ extension FlyerUploadView {
                     self?.networkState?.handleCompletion(screen: .bookmarks, completion)
                 } receiveValue: { [weak self] categories in
                     guard let self = self else { return }
+
                     if self.flyerCategory == nil || self.flyerCategory.isEmpty {
                         self.flyerCategory = categories.first
                     }

--- a/Volume/Views/Flyers/FlyerCellPast.swift
+++ b/Volume/Views/Flyers/FlyerCellPast.swift
@@ -15,7 +15,7 @@ struct FlyerCellPast: View {
     let flyer: Flyer
     let navigationSource: NavigationSource
 
-    @StateObject var urlImageModel: URLImageModel
+    @ObservedObject var urlImageModel: URLImageModel
     @EnvironmentObject private var userData: UserData
     @ObservedObject var viewModel: FlyersView.ViewModel
 

--- a/Volume/Views/Flyers/FlyerCellThisWeek.swift
+++ b/Volume/Views/Flyers/FlyerCellThisWeek.swift
@@ -19,7 +19,7 @@ struct FlyerCellThisWeek: View {
     let organizationNameFont: Font
 
     @State private var bookmarkRequestInProgress: Bool = false
-    @StateObject var urlImageModel: URLImageModel
+    @ObservedObject var urlImageModel: URLImageModel
     @EnvironmentObject private var userData: UserData
     @ObservedObject var viewModel: FlyersView.ViewModel
 

--- a/Volume/Views/Flyers/FlyerCellUpcoming.swift
+++ b/Volume/Views/Flyers/FlyerCellUpcoming.swift
@@ -16,7 +16,7 @@ struct FlyerCellUpcoming: View {
     let navigationSource: NavigationSource
 
     @State private var bookmarkRequestInProgress: Bool = false
-    @StateObject var urlImageModel: URLImageModel
+    @ObservedObject var urlImageModel: URLImageModel
     @EnvironmentObject private var userData: UserData
     @ObservedObject var viewModel: FlyersView.ViewModel
 

--- a/Volume/Views/Orgs Admin/FlyerUploadView.swift
+++ b/Volume/Views/Orgs Admin/FlyerUploadView.swift
@@ -17,7 +17,7 @@ struct FlyerUploadView: View {
     @StateObject var viewModel = ViewModel()
 
     var flyer: Flyer?
-    var isEditing: Bool = false
+    var isEditing: Bool
     let organization: Organization?
 
     // MARK: - Constants

--- a/Volume/Views/Orgs Admin/OrgFlyerCellView.swift
+++ b/Volume/Views/Orgs Admin/OrgFlyerCellView.swift
@@ -16,7 +16,7 @@ struct OrgFlyerCellView: View {
     let navigationSource: NavigationSource
 
     @State private var showConfirmation: Bool = false
-    @StateObject var urlImageModel: URLImageModel
+    @ObservedObject var urlImageModel: URLImageModel
     @EnvironmentObject private var userData: UserData
     @ObservedObject var viewModel: OrgsAdminView.ViewModel
 

--- a/Volume/Views/Orgs Admin/OrgsAdminView.swift
+++ b/Volume/Views/Orgs Admin/OrgsAdminView.swift
@@ -32,16 +32,13 @@ struct OrgsAdminView: View {
     // MARK: - UI
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: Constants.sectionSpacing) {
-                titleUploadSection
-                slidingTabBar
-                flyersSection
+        ZStack(alignment: .center) {
+            mainContent
 
-                Spacer()
+            if viewModel.showSpinner {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
             }
-            .padding(.top, Constants.topPadding)
-            .padding(.horizontal, Constants.sidePadding)
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
@@ -67,7 +64,7 @@ struct OrgsAdminView: View {
 
             viewModel.setupEnvironment(networkState: networkState)
             Task {
-                await viewModel.fetchContent(for: organization)
+                await viewModel.refreshContent(for: organization)
             }
         }
         .onChange(of: viewModel.selectedTab) { _ in
@@ -79,6 +76,20 @@ struct OrgsAdminView: View {
             Task {
                 await viewModel.refreshContent(for: organization)
             }
+        }
+    }
+
+    private var mainContent: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: Constants.sectionSpacing) {
+                titleUploadSection
+                slidingTabBar
+                flyersSection
+
+                Spacer()
+            }
+            .padding(.top, Constants.topPadding)
+            .padding(.horizontal, Constants.sidePadding)
         }
     }
 
@@ -140,12 +151,10 @@ struct OrgsAdminView: View {
         LazyVStack(alignment: .leading, spacing: 16) {
             flyersSectionTitle
 
-            // TODO: Replace with Cindy's custom flyer cell
-
             switch viewModel.displayedFlyers {
             case .none:
                 ForEach(0..<3) { _ in
-                    FlyerCellPast.Skeleton()
+                    OrgFlyerCellView.Skeleton()
                 }
             case .some(let flyers):
                 if flyers.isEmpty {
@@ -156,7 +165,8 @@ struct OrgsAdminView: View {
                             OrgFlyerCellView(
                                 flyer: flyer,
                                 navigationSource: .orgsAdmin,
-                                urlImageModel: URLImageModel(urlString: urlString)
+                                urlImageModel: URLImageModel(urlString: urlString),
+                                viewModel: viewModel
                             )
                         }
                     }

--- a/Volume/Views/Orgs Admin/OrgsAdminView.swift
+++ b/Volume/Views/Orgs Admin/OrgsAdminView.swift
@@ -104,7 +104,7 @@ struct OrgsAdminView: View {
 
     private var uploadFlyerButton: some View {
         NavigationLink {
-            FlyerUploadView(organization: organization)
+            FlyerUploadView(isEditing: false, organization: organization)
         } label: {
             VStack(alignment: .center, spacing: 8) {
                 Image.volume.upload


### PR DESCRIPTION
## Overview

Added the functionality for organizations to edit and delete their flyers.

## Updates

Replaced the GraphQL mutation for edit flyer with a multipart form data POST request. Please disregard the issue mentioned in next steps.

## Changes Made

### Edit Flyer

- Wrote a GraphQL mutation to edit a flyer given the following fields:
    - `id`: String (required)
    - `title`: String
    - `startDate`: String
    - `location`: String
    - `imageB64`: String
    - `flyerURL`: String
    - `endDate`: String
    - `categorySlug`: String
- The edit flyer page reuses the original `UploadFlyerView` but with other changes depending the `isEditing` property.
- All fields should be filled in automatically except for the image. In this case, the user will still be able to edit the flyer (the criteria is different when editing).
- On success, the view is dismissed and the admin page gets refreshed to prevent the user from editing the flyer with incorrect starter fields.

### Delete Flyer

- Wrote a GraphQL mutation to delete a flyer given the flyer ID.
- There are two ways to delete a flyer:
    1. Through the dropdown menu.
    2. In the edit flyer page.
- When deleting a flyer, a confirmation popup is displayed where the user must confirm before deletion.
- On success, the view is dismissed and the admin page gets refreshed to prevent the user from deleting a flyer that has already been deleted.

### Other Changes

- In both of these cases, a spinner is used to make the user experience even better.
- Added a loading skeleton for the flyer cells.

## Test Coverage

I did some very thorough testing for both of these implementations. First, I made sure that both methods of deleting a flyer properly deletes it from the database. Additionally, I made sure that the UI gets updated instantly upon success. However, there isn’t an error message when deleting a flyer. If an error occurs, the spinner just simply stops loading and the view is NOT dismissed.

After testing flyer deletion, I tested flyer editing. Every single field was tested as well as the criteria to update the state of the edit flyer button. This works perfectly except that I am currently using the GraphQL mutation to edit a flyer instead of the HTTP request with multipart form data. We will need backend to implement this in order for image uploads to work properly.

Finally, I did some edge case testing by seeing if uploading a flyer, deleting a flyer, and editing a flyer worked back to back. Things seem to work just fine.

## Next Steps

I will need to implement the edit flyer HTTP request on the backend side so that we can implement this on the frontend. The user will not be able to edit the image for large images until this issue is resolved; however, this is good for now.

## Screenshots
Note that in this video, I was adding the deleted flyer again directly through the database so that I could test it again.

https://github.com/cuappdev/volume-ios/assets/75594943/eca0ffdf-1be3-44be-b456-2ec4b10ee74f