### PR TITLE
Flyer Bookmarks Page

### DIFF
--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -44,7 +44,7 @@ enum Message {
     var subtitle: String {
         switch self {
         case .noBookmarkedFlyers:
-            return "You have no saved flyers"
+            return "You have no saved flyers for this section"
         case .noBookmarkedArticles:
             return "You have no saved articles"
         case .noBookmarkedMagazines:
@@ -60,7 +60,7 @@ enum Message {
         case .upToDateFlyers, .noFlyersPast, .noFlyersUpcoming:
             return "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com."
         case .noFlyersOrgAdmin:
-            return "Upload a flyer by above to see them displayed here"
+            return "Upload a flyer above to see them displayed here"
         }
     }
 

--- a/Volume/Views/Flyers/FlyerCellUpcoming.swift
+++ b/Volume/Views/Flyers/FlyerCellUpcoming.swift
@@ -24,7 +24,7 @@ struct FlyerCellUpcoming: View {
 
     private struct Constants {
         static let buttonSize: CGSize = CGSize(width: 18, height: 18)
-        static let cellWidth: CGFloat = 325
+        static let cellWidth: CGFloat = 352
         static let cellHeight: CGFloat = 92
         static let dateFont: Font = .helveticaRegular(size: 12)
         static let imageHeight: CGFloat = 92

--- a/Volume/Views/MainView and Tabs/BookmarksView.swift
+++ b/Volume/Views/MainView and Tabs/BookmarksView.swift
@@ -130,6 +130,7 @@ struct BookmarksView: View {
                         case .none:
                             ForEach(0..<6) { _ in
                                 FlyerCellUpcoming.Skeleton()
+                                    .padding(.leading, Constants.sidePadding)
                             }
                         case .some(let flyers):
                             ForEach(flyers) { flyer in

--- a/Volume/Views/MainView and Tabs/FlyersView.swift
+++ b/Volume/Views/MainView and Tabs/FlyersView.swift
@@ -25,7 +25,6 @@ struct FlyersView: View {
         static let dailyImageSize: CGSize = CGSize(width: 340, height: 340)
         static let dropdownWidth: CGFloat = 128
         static let endMessageWidth: CGFloat = 250
-        static let gridRows: Array = Array(repeating: GridItem(.flexible()), count: 3)
         static let listHorizontalPadding: CGFloat = 16
         static let rowVerticalPadding: CGFloat = 6
         static let spacing: CGFloat = 16

--- a/Volume/Views/Orgs Admin/OrgFlyerCellView.swift
+++ b/Volume/Views/Orgs Admin/OrgFlyerCellView.swift
@@ -32,17 +32,48 @@ struct OrgFlyerCellView: View {
     // MARK: - UI
 
     var body: some View {
-        HStack(alignment: .top, spacing: Constants.horizontalSpacing) {
-            imageFrame
-
-            VStack(alignment: .leading, spacing: 8) {
-                organizationName
-                flyerTitle
-                flyerDate
-                flyerLocation
-            }
+        if let url = flyer.flyerUrl {
+            cellLinkView(url: url)
+        } else {
+            cellNoLinkView
         }
-        .padding(.bottom, 16)
+    }
+
+    private func cellLinkView(url: URL) -> some View {
+        ZStack(alignment: .topTrailing) {
+            Link(destination: url) {
+                HStack(alignment: .top, spacing: Constants.horizontalSpacing) {
+                    imageFrame
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        organizationName
+                        flyerTitle
+                        flyerDate
+                        flyerLocation
+                    }
+                }
+            }
+            .buttonStyle(EmptyButtonStyle())
+
+            tripleDotsButton
+        }
+    }
+
+    private var cellNoLinkView: some View {
+        ZStack(alignment: .topTrailing) {
+            HStack(alignment: .top, spacing: Constants.horizontalSpacing) {
+                imageFrame
+
+                VStack(alignment: .leading, spacing: 8) {
+                    organizationName
+                    flyerTitle
+                    flyerDate
+                    flyerLocation
+                }
+            }
+
+            tripleDotsButton
+        }
     }
 
     private var imageFrame: some View {
@@ -68,8 +99,6 @@ struct OrgFlyerCellView: View {
                 .lineLimit(2)
 
             Spacer()
-
-            tripleDotsButton
         }
         .padding(.bottom, -Constants.verticalSpacing)
     }
@@ -94,7 +123,7 @@ struct OrgFlyerCellView: View {
                         .frame(width: Constants.circleSize, height: Constants.circleSize)
                 }
             }
-            .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+            .padding(EdgeInsets(top: 0, leading: 16, bottom: 16, trailing: 0))
         }
         .confirmationDialog(
             "Removing a flyer will delete it from Volume’s feed.",


### PR DESCRIPTION
## Overview

Implemented the new flyers bookmarks page.

## Changes Made

### Flyer Bookmarks

- Implemented the new flyer bookmarks page which has two sections: upcoming and past
- These two sections have different filters for the category. The dropdown values depend on which flyers are bookmarked. Not all of the categories are shown.
- There are empty states for both sections.

### Other Changes

- Fixed typo in empty state message for no flyers in the orgs admin page.
- Added the ability to load the flyer URL when tapping on the cell in the org admin page, similar to how we have it for the rest of the flyer cells (if the flyer URL exists).

## Test Coverage

I tested with both upcoming and past flyers. The filters seem to work separately for both which is what we want. Additionally, I tried to unbookmark and then bookmark for more thorough testing. Everything seems to be working just fine.

## Screenshots
Before:
<img src="https://github.com/cuappdev/volume-ios/assets/75594943/8a881eba-617a-454d-b651-70323e36306e" width="300" height="auto">

After:

https://github.com/cuappdev/volume-ios/assets/75594943/83f4c88f-443d-4c14-bc74-16916d54c4b1


After v2 (I changed the spacing between the headers after recording this):

https://github.com/cuappdev/volume-ios/assets/75594943/0094fc04-2814-45b0-b048-53060d3431e6