### PR TITLE
Organization Detail View

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -74,6 +74,15 @@
 		2E9349AC2AC718D70098CAC8 /* FlyerUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9349AB2AC718D70098CAC8 /* FlyerUploadViewModel.swift */; };
 		2EA7DB7329DBEF7C001D7B8A /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA7DB7229DBEF7C001D7B8A /* UIImage+Extension.swift */; };
 		2EA7DB7929DC0EE5001D7B8A /* URLImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA7DB7829DC0EE5001D7B8A /* URLImageModel.swift */; };
+		2EAA0CC22B0723E500379F0B /* OrganizationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CC12B0723E500379F0B /* OrganizationList.swift */; };
+		2EAA0CC42B0725E100379F0B /* OrganizationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CC32B0725E100379F0B /* OrganizationListViewModel.swift */; };
+		2EAA0CC62B072FA500379F0B /* FollowingOrganizationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CC52B072FA400379F0B /* FollowingOrganizationRow.swift */; };
+		2EAA0CC82B0732C100379F0B /* MoreOrganizationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CC72B0732C100379F0B /* MoreOrganizationRow.swift */; };
+		2EAA0CCA2B073E1000379F0B /* OrganizationDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CC92B073E1000379F0B /* OrganizationDetail.swift */; };
+		2EAA0CCD2B07416600379F0B /* OrganizationDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CCC2B07416600379F0B /* OrganizationDetailHeader.swift */; };
+		2EAA0CCF2B0741D600379F0B /* OrganizationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CCE2B0741D600379F0B /* OrganizationContentView.swift */; };
+		2EAA0CD12B07468200379F0B /* MediaText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CD02B07468200379F0B /* MediaText.swift */; };
+		2EAA0CD32B074CDA00379F0B /* OrganizationContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EAA0CD22B074CDA00379F0B /* OrganizationContentViewModel.swift */; };
 		2EB5568829B9485700794423 /* MagsScrollbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568729B9485700794423 /* MagsScrollbarView.swift */; };
 		2EB5568C29B94A5600794423 /* PageIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB5568B29B94A5600794423 /* PageIndicatorView.swift */; };
 		2EC811EC2AC6875500ED1ACC /* OrgsLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC811EB2AC6875500ED1ACC /* OrgsLoginView.swift */; };
@@ -270,6 +279,15 @@
 		2E9349AB2AC718D70098CAC8 /* FlyerUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyerUploadViewModel.swift; sourceTree = "<group>"; };
 		2EA7DB7229DBEF7C001D7B8A /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		2EA7DB7829DC0EE5001D7B8A /* URLImageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLImageModel.swift; sourceTree = "<group>"; };
+		2EAA0CC12B0723E500379F0B /* OrganizationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationList.swift; sourceTree = "<group>"; };
+		2EAA0CC32B0725E100379F0B /* OrganizationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationListViewModel.swift; sourceTree = "<group>"; };
+		2EAA0CC52B072FA400379F0B /* FollowingOrganizationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowingOrganizationRow.swift; sourceTree = "<group>"; };
+		2EAA0CC72B0732C100379F0B /* MoreOrganizationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOrganizationRow.swift; sourceTree = "<group>"; };
+		2EAA0CC92B073E1000379F0B /* OrganizationDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationDetail.swift; sourceTree = "<group>"; };
+		2EAA0CCC2B07416600379F0B /* OrganizationDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationDetailHeader.swift; sourceTree = "<group>"; };
+		2EAA0CCE2B0741D600379F0B /* OrganizationContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationContentView.swift; sourceTree = "<group>"; };
+		2EAA0CD02B07468200379F0B /* MediaText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaText.swift; sourceTree = "<group>"; };
+		2EAA0CD22B074CDA00379F0B /* OrganizationContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizationContentViewModel.swift; sourceTree = "<group>"; };
 		2EB5568729B9485700794423 /* MagsScrollbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagsScrollbarView.swift; sourceTree = "<group>"; };
 		2EB5568B29B94A5600794423 /* PageIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageIndicatorView.swift; sourceTree = "<group>"; };
 		2EC811EB2AC6875500ED1ACC /* OrgsLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgsLoginView.swift; sourceTree = "<group>"; };
@@ -552,6 +570,19 @@
 			path = Flyers;
 			sourceTree = "<group>";
 		};
+		2EAA0CCB2B07413600379F0B /* Organizations */ = {
+			isa = PBXGroup;
+			children = (
+				2EAA0CC52B072FA400379F0B /* FollowingOrganizationRow.swift */,
+				2EAA0CC72B0732C100379F0B /* MoreOrganizationRow.swift */,
+				2EAA0CCE2B0741D600379F0B /* OrganizationContentView.swift */,
+				2EAA0CC92B073E1000379F0B /* OrganizationDetail.swift */,
+				2EAA0CCC2B07416600379F0B /* OrganizationDetailHeader.swift */,
+				2EAA0CC12B0723E500379F0B /* OrganizationList.swift */,
+			);
+			path = Organizations;
+			sourceTree = "<group>";
+		};
 		2EC811EA2AC6873600ED1ACC /* Orgs Admin */ = {
 			isa = PBXGroup;
 			children = (
@@ -647,6 +678,7 @@
 				2E6A7D6F29DAAFB5002F5250 /* Flyers */,
 				0647BF8C2577F60400D44BC7 /* MainView and Tabs */,
 				060FFDD82577EC800052F3EA /* Onboarding */,
+				2EAA0CCB2B07413600379F0B /* Organizations */,
 				2EC811EA2AC6873600ED1ACC /* Orgs Admin */,
 				2E6A7D5829D9E7CA002F5250 /* Other */,
 				3360B9D62926129100A923A6 /* Publications */,
@@ -691,6 +723,8 @@
 				2E6A7D7029DAB2AB002F5250 /* FlyersViewModel.swift */,
 				2E9349AB2AC718D70098CAC8 /* FlyerUploadViewModel.swift */,
 				2E05005A29C65B82001B4131 /* MagazinesViewModel.swift */,
+				2EAA0CD22B074CDA00379F0B /* OrganizationContentViewModel.swift */,
+				2EAA0CC32B0725E100379F0B /* OrganizationListViewModel.swift */,
 				2E6C36122AF5FF45004A54BB /* OrgsAdminViewModel.swift */,
 				2EC811ED2AC6B20600ED1ACC /* OrgsLoginViewModel.swift */,
 				3360B9DD29274B9500A923A6 /* PublicationContentViewModel.swift */,
@@ -711,6 +745,7 @@
 				2E6A7D6929DA893B002F5250 /* HamburgerMenuView.swift */,
 				7E416C312561D7870010D70B /* Header.swift */,
 				2E38E14929E5CBB8006323E5 /* LottieView.swift */,
+				2EAA0CD02B07468200379F0B /* MediaText.swift */,
 				3392D71B2937BF4E005165F6 /* ReaderToolbarView.swift */,
 				2E81EB6729F4FC0900A288C1 /* ScrollFadingView.swift */,
 				3375EC042937F7C9005A046F /* SemesterMenuView.swift */,
@@ -1070,6 +1105,7 @@
 				2E6A7D5029D9E3D3002F5250 /* TrendingView.swift in Sources */,
 				2E4BAE8429DE7FA700EB16D6 /* EmptyButtonStyle.swift in Sources */,
 				7EC15DA1257767ED0053BA0B /* MorePublicationRow.swift in Sources */,
+				2EAA0CCA2B073E1000379F0B /* OrganizationDetail.swift in Sources */,
 				3360B9E229288DA900A923A6 /* SlidingTabBarView.swift in Sources */,
 				7EC15DA2257767ED0053BA0B /* PublicationDetail.swift in Sources */,
 				2E6A7D5229D9E6F8002F5250 /* BookmarksView.swift in Sources */,
@@ -1077,7 +1113,9 @@
 				7EC15DA3257767ED0053BA0B /* PublicationList.swift in Sources */,
 				2EFA7EC12B0075A700E82ABE /* ArticleWidgetEntry.swift in Sources */,
 				335E692627DFDC2700FBDE3A /* UIFont+Extension.swift in Sources */,
+				2EAA0CC22B0723E500379F0B /* OrganizationList.swift in Sources */,
 				2E9349AA2AC718C70098CAC8 /* FlyerUploadView.swift in Sources */,
+				2EAA0CD32B074CDA00379F0B /* OrganizationContentViewModel.swift in Sources */,
 				2EFA7ED82B00BB9900E82ABE /* FlyerWidgetEntry.swift in Sources */,
 				0685AAA1259EBA3800DD55C4 /* WebView.swift in Sources */,
 				2E3D327329DE1BD600E7B0A1 /* TrendingFlyerCell.swift in Sources */,
@@ -1090,6 +1128,7 @@
 				0685AA9E259EA84900DD55C4 /* BrowserView.swift in Sources */,
 				2E6A7D7729DAC784002F5250 /* FlyerCellPast.swift in Sources */,
 				2E3D327129DE058D00E7B0A1 /* TrendingMainArticleCell.swift in Sources */,
+				2EAA0CD12B07468200379F0B /* MediaText.swift in Sources */,
 				2E4B30DE29CCEE9B000D6AA6 /* HapticTouch.swift in Sources */,
 				2E6A7D7329DAB5BC002F5250 /* FlyerCellThisWeek.swift in Sources */,
 				7E23DFD2254A05EF0001C3A3 /* Color+Extension.swift in Sources */,
@@ -1111,6 +1150,7 @@
 				2E37058F29F78642002D2D42 /* AboutVolumeView.swift in Sources */,
 				33E851A6290AE6ED004453D2 /* ListBackgroundModifier.swift in Sources */,
 				BC72AEBA29259D4500209573 /* API.swift in Sources */,
+				2EAA0CC62B072FA500379F0B /* FollowingOrganizationRow.swift in Sources */,
 				2E05005D29C66999001B4131 /* MagazinesView.swift in Sources */,
 				2EC811EC2AC6875500ED1ACC /* OrgsLoginView.swift in Sources */,
 				2E6A7D6329DA39D3002F5250 /* BookmarksViewModel.swift in Sources */,
@@ -1118,6 +1158,7 @@
 				2E6A7D5629D9E73E002F5250 /* ReadsView.swift in Sources */,
 				2E6C36112AF5E355004A54BB /* OrgsAdminView.swift in Sources */,
 				061DB39725571D760038BEF5 /* Font+Extension.swift in Sources */,
+				2EAA0CC82B0732C100379F0B /* MoreOrganizationRow.swift in Sources */,
 				3334F4A02705269800CF0987 /* AppDelegate.swift in Sources */,
 				3349BF6F290DC1E900B0FD3A /* WeeklyDebriefButton.swift in Sources */,
 				061233A12553127C0025F7E0 /* UnderlinedText.swift in Sources */,
@@ -1144,6 +1185,7 @@
 				2E0D036D29F1CFA6008EAF69 /* JSONDecoder+Extension.swift in Sources */,
 				2EFA7ECE2B007EDC00E82ABE /* ArticleWidgetView.swift in Sources */,
 				3360B9DC29274B8200A923A6 /* PublicationContentView.swift in Sources */,
+				2EAA0CCF2B0741D600379F0B /* OrganizationContentView.swift in Sources */,
 				2E6A7D7529DABB23002F5250 /* FlyerCellUpcoming.swift in Sources */,
 				331159D727D41C89003B0F06 /* Image+Extensions.swift in Sources */,
 				2E6A7D6C29DAA2E7002F5250 /* Flyer.swift in Sources */,
@@ -1158,9 +1200,11 @@
 				95A79FB42622255D00CADF88 /* TabContainer.swift in Sources */,
 				2EFA7EE92B01361100E82ABE /* FlyerWidgetIntent.swift in Sources */,
 				2EFA7EE02B00BD3300E82ABE /* Widget+Extension.swift in Sources */,
+				2EAA0CCD2B07416600379F0B /* OrganizationDetailHeader.swift in Sources */,
 				33913A0C27D89E0A00C5718D /* TabBarReader.swift in Sources */,
 				A2A5CC1027D567EA0000F377 /* MagazineCell.swift in Sources */,
 				50C360542759482A006CDB2E /* DebriefArticleView.swift in Sources */,
+				2EAA0CC42B0725E100379F0B /* OrganizationListViewModel.swift in Sources */,
 				063EED25257BF8A7002136EE /* Network.swift in Sources */,
 				2E1DDD632AD0546300627C52 /* String+Extension.swift in Sources */,
 				922FE2FD29316B0D00E14911 /* SearchDropdownView.swift in Sources */,

--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -1445,7 +1445,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
@@ -1458,7 +1458,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1477,7 +1477,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1489,7 +1489,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume/Analytics/Analytics.swift
+++ b/Volume/Analytics/Analytics.swift
@@ -31,6 +31,10 @@ enum VolumeEvent: String {
     case followPublication = "follow_publication"
     case unfollowPublication = "unfollow_publication"
 
+    // Organization-specific events
+    case followOrganization = "follow_organization"
+    case unfollowOrganization = "unfollow_organization"
+
     // Article-specific events
     case openArticle = "open_article"
     case shareArticle = "share_article"
@@ -54,7 +58,15 @@ enum VolumeEvent: String {
     case bookmarkFlyer = "bookmark_flyer"
 
     enum EventType {
-        case article, flyer, general, magazine, notification, notificationInterval, publication, page
+        case article
+        case flyer
+        case general
+        case magazine
+        case notification
+        case notificationInterval
+        case organization
+        case publication
+        case page
     }
 
     func toEvent(
@@ -72,6 +84,8 @@ enum VolumeEvent: String {
             parameters = ["magazineID": value]
         case .notificationInterval:
             parameters = ["duration": value]
+        case .organization:
+            parameters = ["organizationSlug": value]
         case .publication:
             parameters = ["publicationSlug": value]
         default:

--- a/Volume/Extensions/Image+Extensions.swift
+++ b/Volume/Extensions/Image+Extensions.swift
@@ -28,6 +28,7 @@ extension Image {
         let follow = Image("follow")
         let followed = Image("followed")
         let info = Image("info")
+        let insta = Image("insta")
         let leftArrow = Image("left-arrow")
         let link = Image(systemName: "link")
         let location = Image("location")

--- a/Volume/Models/Organization.swift
+++ b/Volume/Models/Organization.swift
@@ -15,6 +15,7 @@ struct Organization: Hashable, Identifiable {
     let bio: String?
     let categorySlug: String
     let name: String
+    let numFlyers: Int
     let profileImageUrl: URL?
     let slug: String
     let shoutouts: Int
@@ -29,6 +30,7 @@ struct Organization: Hashable, Identifiable {
         self.bio = organization.bio
         self.categorySlug = organization.categorySlug
         self.name = organization.name
+        self.numFlyers = Int(organization.numFlyers)
         self.profileImageUrl = {
             guard let stringUrl = organization.profileImageUrl else { return nil }
             return URL(string: stringUrl)

--- a/Volume/Models/WeeklyDebrief.swift
+++ b/Volume/Models/WeeklyDebrief.swift
@@ -11,7 +11,6 @@ import Foundation
 struct WeeklyDebrief: Codable {
     let creationDate: Date
     let expirationDate: Date
-    let numBookmarkedArticles: Int
     let numReadArticles: Int
     let numShoutouts: Int
     let readArticleIDs: [ArticleID]
@@ -21,7 +20,6 @@ struct WeeklyDebrief: Codable {
     init(from weeklyDebrief: GetWeeklyDebriefQuery.Data.User.WeeklyDebrief) {
         creationDate = Date.from(iso8601: weeklyDebrief.creationDate)
         expirationDate = Date.from(iso8601: weeklyDebrief.expirationDate)
-        numBookmarkedArticles = Int(weeklyDebrief.numBookmarkedArticles)
         numReadArticles = Int(weeklyDebrief.numReadArticles)
         numShoutouts = Int(weeklyDebrief.numShoutouts)
         readArticleIDs = weeklyDebrief.readArticles.map(\.fragments.articleFields.id)

--- a/Volume/Networking/ArticlesMutations.graphql
+++ b/Volume/Networking/ArticlesMutations.graphql
@@ -10,8 +10,8 @@ mutation ReadArticle($id: String!, $uuid: String!) {
   }
 }
 
-mutation BookmarkArticle($uuid: String!) {
-  bookmarkArticle(uuid: $uuid) {
+mutation BookmarkArticle($uuid: String!, $articleID: String!) {
+  bookmarkArticle(uuid: $uuid, articleID: $articleID) {
     id
   }
 }

--- a/Volume/Networking/FlyerMutations.graphql
+++ b/Volume/Networking/FlyerMutations.graphql
@@ -1,5 +1,5 @@
-mutation BookmarkFlyer($uuid: String!) {
-  bookmarkArticle(uuid: $uuid) {
+mutation BookmarkFlyer($uuid: String!, $flyerID: String!) {
+  bookmarkFlyer(uuid: $uuid, flyerID: $flyerID) {
     id
   }
 }

--- a/Volume/Networking/FlyerQueries.graphql
+++ b/Volume/Networking/FlyerQueries.graphql
@@ -43,8 +43,8 @@ query GetAllFlyerCategories {
   getAllFlyerCategories
 }
 
-query GetFlyersByOrganizationSlug($limit: Float, $slug: String!) {
-  flyers: getFlyersByOrganizationSlug(limit: $limit, slug: $slug) {
+query GetFlyersByOrganizationSlug($limit: Float, $slug: String!, $offset: Float) {
+  flyers: getFlyersByOrganizationSlug(limit: $limit, slug: $slug, offset: $offset) {
     ...flyerFields
   }
 }

--- a/Volume/Networking/MagazineMutations.graphql
+++ b/Volume/Networking/MagazineMutations.graphql
@@ -4,8 +4,8 @@ mutation IncrementMagazineShoutouts($id: String!, $uuid: String!) {
   }
 }
 
-mutation BookmarkMagazine($uuid: String!) {
-  bookmarkArticle(uuid: $uuid) {
+mutation BookmarkMagazine($uuid: String!, $magazineID: String!) {
+  bookmarkMagazine(uuid: $uuid, magazineID: $magazineID) {
     id
   }
 }

--- a/Volume/Networking/Network.swift
+++ b/Volume/Networking/Network.swift
@@ -155,7 +155,7 @@ class NetworkState: ObservableObject {
     @Published var networkScreenFailed: [Screen: Bool] = [:]
 
     public enum Screen: String, CaseIterable {
-        case bookmarks, flyers, publicationDetail, publications, reads, search, trending
+        case bookmarks, flyers, publicationDetail, reads, search, trending
     }
 
     func handleCompletion(screen: Screen, _ completion: Subscribers.Completion<WrappedGraphQLError>) {

--- a/Volume/Networking/OrganizationQueries.graphql
+++ b/Volume/Networking/OrganizationQueries.graphql
@@ -4,6 +4,7 @@ fragment organizationFields on Organization {
   bio
   categorySlug
   name
+  numFlyers
   profileImageURL
   slug
   shoutouts

--- a/Volume/Networking/OrganizationQueries.graphql
+++ b/Volume/Networking/OrganizationQueries.graphql
@@ -28,7 +28,7 @@ query CheckAccessCode($accessCode: String!, $slug: String!) {
   }
 }
 
-query GetAllOrganizationNames {
+query GetAllOrganizations {
   organizations: getAllOrganizations {
     ...organizationFields
   }

--- a/Volume/Networking/UserMutations.graphql
+++ b/Volume/Networking/UserMutations.graphql
@@ -1,21 +1,37 @@
 mutation CreateUser($deviceToken: String!, $followedPublicationSlugs: [String!]!) {
-    user: createUser(deviceType: "IOS", deviceToken: $deviceToken, followedPublications: $followedPublicationSlugs) {
-        uuid
-    }
+  user: createUser(deviceType: "IOS", deviceToken: $deviceToken, followedPublications: $followedPublicationSlugs) {
+      uuid
+  }
 }
 
 mutation FollowPublication($slug:String!, $uuid:String!) {
-    user: followPublication(slug:$slug, uuid:$uuid) {
-        followedPublications {
-            slug
-        }
+  user: followPublication(slug:$slug, uuid:$uuid) {
+    followedPublications {
+      slug
     }
+  }
 }
 
 mutation UnfollowPublication($slug:String!, $uuid:String!) {
-    user: unfollowPublication(slug:$slug, uuid:$uuid) {
-        followedPublications {
-            slug
-        }
+  user: unfollowPublication(slug:$slug, uuid:$uuid) {
+    followedPublications {
+      slug
     }
+  }
+}
+
+mutation FollowOrganization($slug:String!, $uuid:String!) {
+  user: followOrganization(slug:$slug, uuid:$uuid) {
+    followedOrganizations {
+      slug
+    }
+  }
+}
+
+mutation UnfollowOrganization($slug:String!, $uuid:String!) {
+  user: unfollowOrganization(slug:$slug, uuid:$uuid) {
+    followedOrganizations {
+      slug
+    }
+  }
 }

--- a/Volume/Networking/UserQueries.graphql
+++ b/Volume/Networking/UserQueries.graphql
@@ -5,7 +5,6 @@ query GetWeeklyDebrief($uuid:String!) {
             expirationDate
             numReadArticles
             numShoutouts
-            numBookmarkedArticles
             readArticles {
                 ...articleFields
             }

--- a/Volume/Supporting Views/MediaText.swift
+++ b/Volume/Supporting Views/MediaText.swift
@@ -1,0 +1,29 @@
+//
+//  MediaText.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+
+/// A view representing a social media text.
+struct MediaText: View {
+
+    // MARK: - Properties
+
+    let title: String
+    let url: URL
+
+    // MARK: - UI
+
+    var body: some View {
+        Link(title, destination: url)
+            .font(.helveticaRegular(size: 12))
+            .foregroundColor(Color.volume.orange)
+            .padding(.trailing, 10)
+            .lineLimit(1)
+    }
+
+}

--- a/Volume/Supporting Views/VolumeMessage.swift
+++ b/Volume/Supporting Views/VolumeMessage.swift
@@ -14,9 +14,11 @@ enum Message {
     case noBookmarkedFlyers
     case noBookmarkedMagazines
     case noFlyersOrgAdmin
+    case noFlyersOrgDetail
     case noFlyersPast
     case noFlyersUpcoming
     case noFollowingHome
+    case noFollowingOrganizations
     case noFollowingPublications
     case noSearchResults
     case upToDateArticles
@@ -26,33 +28,37 @@ enum Message {
         switch self {
         case .noBookmarkedArticles, .noBookmarkedMagazines, .noFollowingHome, .noSearchResults, .noBookmarkedFlyers:
             return "Nothing to see here!"
+        case .noFollowingOrganizations:
+            return "No followed organizations."
         case .noFollowingPublications:
-            return "No Followed Publications"
+            return "No followed publications."
         case .upToDateArticles:
             return "You're up to date!"
         case .upToDateFlyers:
             return "Are you an organization?"
         case .noFlyersPast:
-            return "No past flyers"
+            return "No past flyers."
         case .noFlyersUpcoming:
-            return "No upcoming flyers for this category"
+            return "No upcoming flyers for this category."
         case .noFlyersOrgAdmin:
-            return "No flyers to display"
+            return "No flyers to display."
+        case .noFlyersOrgDetail:
+            return "There's nothing here."
         }
     }
 
     var subtitle: String {
         switch self {
         case .noBookmarkedFlyers:
-            return "You have no saved flyers for this section"
+            return "You have no saved flyers for this section."
         case .noBookmarkedArticles:
-            return "You have no saved articles"
+            return "You have no saved articles."
         case .noBookmarkedMagazines:
-            return "You have no saved magazines"
+            return "You have no saved magazines."
         case .noFollowingHome:
-            return "Follow some student publications that you are interested in"
-        case .noFollowingPublications:
-            return "Follow some below and we'll display them here"
+            return "Follow some student publications that you are interested in."
+        case .noFollowingOrganizations, .noFollowingPublications:
+            return "Follow some below and we'll display them here."
         case .upToDateArticles:
             return "You've seen all new articles from the publications you're following."
         case .noSearchResults:
@@ -60,7 +66,9 @@ enum Message {
         case .upToDateFlyers, .noFlyersPast, .noFlyersUpcoming:
             return "If you want to see your organization’s events on Volume, email us at volumeappdev@gmail.com."
         case .noFlyersOrgAdmin:
-            return "Upload a flyer above to see them displayed here"
+            return "Upload a flyer above to see them displayed here."
+        case .noFlyersOrgDetail:
+            return "It seems like this organization hasn’t published any flyers yet."
         }
     }
 

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -281,17 +281,19 @@ class UserData: ObservableObject {
         }
 
         if isSaved {
-            cancellables[.bookmarkArticle(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid, articleID: article.id))
-                .sink { completion in
-                    if case let .failure(error) = completion {
-                        print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
-                    }
-                    requestInProgress = false
-                } receiveValue: { _ in
-                    if !self.savedArticleIDs.contains(article.id) {
-                        self.savedArticleIDs.insert(article.id, at: 0)
-                    }
+            cancellables[.bookmarkArticle(article)] = Network.shared.publisher(
+                for: BookmarkArticleMutation(uuid: uuid, articleID: article.id)
+            )
+            .sink { completion in
+                if case let .failure(error) = completion {
+                    print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
                 }
+                requestInProgress = false
+            } receiveValue: { _ in
+                if !self.savedArticleIDs.contains(article.id) {
+                    self.savedArticleIDs.insert(article.id, at: 0)
+                }
+            }
         } else {
             requestInProgress = false
             self.savedArticleIDs.removeAll(where: { $0 == article.id })
@@ -343,17 +345,19 @@ class UserData: ObservableObject {
         }
 
         if isSaved {
-            cancellables[.bookmarkFlyer(flyer)] = Network.shared.publisher(for: BookmarkFlyerMutation(uuid: uuid, flyerID: flyer.id))
-                .sink { completion in
-                    if case let .failure(error) = completion {
-                        print("Error: BookmarkFlyerMutation failed on UserData: \(error.localizedDescription)")
-                    }
-                    requestInProgress = false
-                } receiveValue: { _ in
-                    if !self.savedFlyerIDs.contains(flyer.id) {
-                        self.savedFlyerIDs.insert(flyer.id, at: 0)
-                    }
+            cancellables[.bookmarkFlyer(flyer)] = Network.shared.publisher(
+                for: BookmarkFlyerMutation(uuid: uuid, flyerID: flyer.id)
+            )
+            .sink { completion in
+                if case let .failure(error) = completion {
+                    print("Error: BookmarkFlyerMutation failed on UserData: \(error.localizedDescription)")
                 }
+                requestInProgress = false
+            } receiveValue: { _ in
+                if !self.savedFlyerIDs.contains(flyer.id) {
+                    self.savedFlyerIDs.insert(flyer.id, at: 0)
+                }
+            }
         } else {
             requestInProgress = false
             self.savedFlyerIDs.removeAll(where: { $0 == flyer.id })

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -22,6 +22,7 @@ class UserData: ObservableObject {
     private let isFirstLaunchKey = "isFirstLaunch"
     private let magazineShoutoutsKey = "magazineShoutoutsCounter"
     private let magazinesKey = "savedMagazineIds"
+    private let organizationsKey = "savedOrganizationSlugs"
     private let publicationsKey = "savedPublicationSlugs"
     private let recentSearchesKey = "recentSearchQueries"
     private let userUUIDKey = "userUUID"
@@ -47,6 +48,13 @@ class UserData: ObservableObject {
     @Published private(set) var followedPublicationSlugs: [String] = [] {
         willSet {
             UserDefaults.standard.setValue(newValue, forKey: publicationsKey)
+            self.objectWillChange.send()
+        }
+    }
+
+    @Published private(set) var followedOrganizationSlugs: [String] = [] {
+        willSet {
+            UserDefaults.standard.setValue(newValue, forKey: organizationsKey)
             self.objectWillChange.send()
         }
     }
@@ -133,6 +141,10 @@ class UserData: ObservableObject {
             followedPublicationSlugs = slugs
         }
 
+        if let slugs = UserDefaults.standard.object(forKey: organizationsKey) as? [String] {
+            followedOrganizationSlugs = slugs
+        }
+
         if let shoutoutsCounter = UserDefaults.standard.object(forKey: articleShoutoutsKey) as? [String: Int] {
             articleShoutoutsCounter = shoutoutsCounter
         }
@@ -178,6 +190,10 @@ class UserData: ObservableObject {
         followedPublicationSlugs.contains(publication.slug)
     }
 
+    func isOrganizationFollowed(_ organization: Organization) -> Bool {
+        followedOrganizationSlugs.contains(organization.slug)
+    }
+
     func toggleArticleSaved(_ article: Article, _ bookmarkRequestInProgress: Binding<Bool>) {
         Task {
             await set(
@@ -209,6 +225,16 @@ class UserData: ObservableObject {
             await set(
                 publication: publication,
                 isFollowed: !isPublicationFollowed(publication),
+                followRequestInProgress: followRequestInProgress
+            )
+        }
+    }
+
+    func toggleOrganizationFollowed(_ organization: Organization, _ followRequestInProgress: Binding<Bool>) {
+        Task {
+            await set(
+                organization: organization,
+                isFollowed: !isOrganizationFollowed(organization),
                 followRequestInProgress: followRequestInProgress
             )
         }
@@ -353,7 +379,7 @@ class UserData: ObservableObject {
 
         if isFollowed {
             let followMutation = FollowPublicationMutation(slug: publication.slug, uuid: uuid)
-            cancellables[.follow(publication)] = Network.shared.publisher(for: followMutation)
+            cancellables[.followPublication(publication)] = Network.shared.publisher(for: followMutation)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: FollowPublicationMutation failed on UserData: \(error.localizedDescription)")
@@ -367,7 +393,7 @@ class UserData: ObservableObject {
 
         } else {
             let unfollowMutation = UnfollowPublicationMutation(slug: publication.slug, uuid: uuid)
-            cancellables[.unfollow(publication)] = Network.shared.publisher(for: unfollowMutation)
+            cancellables[.unfollowPublication(publication)] = Network.shared.publisher(for: unfollowMutation)
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: UnfollowPublicationMutation failed on UserData: \(error.localizedDescription)")
@@ -378,14 +404,64 @@ class UserData: ObservableObject {
                 }
         }
     }
+
+    func set(organization: Organization, isFollowed: Bool, followRequestInProgress: Binding<Bool>) async {
+        @Binding var requestInProgress: Bool
+        _requestInProgress = followRequestInProgress
+
+        guard let uuid = uuid else {
+            // User has not finished onboarding
+            if isFollowed {
+                if !self.followedOrganizationSlugs.contains(organization.slug) {
+                    self.followedOrganizationSlugs.insert(organization.slug, at: 0)
+                }
+            } else {
+                self.followedOrganizationSlugs.removeAll(where: { $0 == organization.slug })
+            }
+            requestInProgress = false
+            return
+        }
+
+        if isFollowed {
+            let followMutation = FollowOrganizationMutation(slug: organization.slug, uuid: uuid)
+            cancellables[.followOrganization(organization)] = Network.shared.publisher(for: followMutation)
+                .sink { completion in
+                    if case let .failure(error) = completion {
+                        print("Error: FollowOrganizationMutation failed on UserData: \(error.localizedDescription)")
+                    }
+                    requestInProgress = false
+                } receiveValue: { _ in
+                    if !self.followedOrganizationSlugs.contains(organization.slug) {
+                        self.followedOrganizationSlugs.insert(organization.slug, at: 0)
+                    }
+                }
+
+        } else {
+            let unfollowMutation = UnfollowOrganizationMutation(slug: organization.slug, uuid: uuid)
+            cancellables[.unfollowOrganization(organization)] = Network.shared.publisher(for: unfollowMutation)
+                .sink { completion in
+                    if case let .failure(error) = completion {
+                        print("Error: UnfollowOrganizationMutation failed on UserData: \(error.localizedDescription)")
+                    }
+                    requestInProgress = false
+                } receiveValue: { _ in
+                    self.followedOrganizationSlugs.removeAll(where: { $0 == organization.slug })
+                }
+        }
+    }
+
 }
 
 extension UserData {
+
     private enum Mutation: Hashable {
-        case follow(Publication)
-        case unfollow(Publication)
+        case followPublication(Publication)
+        case unfollowPublication(Publication)
+        case followOrganization(Organization)
+        case unfollowOrganization(Organization)
         case bookmarkArticle(Article)
         case bookmarkMagazine(Magazine)
         case bookmarkFlyer(Flyer)
     }
+
 }

--- a/Volume/Supporting/UserData.swift
+++ b/Volume/Supporting/UserData.swift
@@ -281,7 +281,7 @@ class UserData: ObservableObject {
         }
 
         if isSaved {
-            cancellables[.bookmarkArticle(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid))
+            cancellables[.bookmarkArticle(article)] = Network.shared.publisher(for: BookmarkArticleMutation(uuid: uuid, articleID: article.id))
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: BookmarkArticleMutation failed on UserData: \(error.localizedDescription)")
@@ -312,7 +312,7 @@ class UserData: ObservableObject {
 
         if isSaved {
             cancellables[.bookmarkMagazine(magazine)] = Network.shared.publisher(
-                for: BookmarkMagazineMutation(uuid: uuid)
+                for: BookmarkMagazineMutation(uuid: uuid, magazineID: magazine.id)
             )
             .sink { completion in
                 if case let .failure(error) = completion {
@@ -343,7 +343,7 @@ class UserData: ObservableObject {
         }
 
         if isSaved {
-            cancellables[.bookmarkFlyer(flyer)] = Network.shared.publisher(for: BookmarkFlyerMutation(uuid: uuid))
+            cancellables[.bookmarkFlyer(flyer)] = Network.shared.publisher(for: BookmarkFlyerMutation(uuid: uuid, flyerID: flyer.id))
                 .sink { completion in
                     if case let .failure(error) = completion {
                         print("Error: BookmarkFlyerMutation failed on UserData: \(error.localizedDescription)")

--- a/Volume/View Models/OrganizationContentViewModel.swift
+++ b/Volume/View Models/OrganizationContentViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  OrganizationContentViewModel.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Combine
+import SwiftUI
+
+extension OrganizationContentView {
+
+    @MainActor
+    class ViewModel: ObservableObject {
+
+        // MARK: - Properties
+
+        @Published var flyers: [Flyer]?
+        @Published var hasMorePages: Bool = true
+
+        private var networkState: NetworkState?
+        private var organization: Organization?
+        private var queryBag = Set<AnyCancellable>()
+
+        // MARK: - Property Helpers + Constants
+
+        func setupEnvironmentVariables(networkState: NetworkState, organization: Organization) {
+            self.networkState = networkState
+            self.organization = organization
+        }
+
+        private struct Constants {
+            static let animationDuration: CGFloat = 0.1
+            static let pageSize: Double = 10
+        }
+
+        // MARK: - Network Requests
+
+        func fetchPageIfLast(flyer: Flyer) {
+            if let flyers, flyers.firstIndex(of: flyer) == flyers.index(flyers.endIndex, offsetBy: -1) {
+                Task {
+                    await fetchFlyersPage()
+                }
+            }
+        }
+
+        func fetchFlyersPage() async {
+            guard let organization else { return }
+
+            Network.shared.publisher(
+                for: GetFlyersByOrganizationSlugQuery(
+                    limit: Constants.pageSize,
+                    slug: organization.slug,
+                    offset: Double(flyers?.count ?? 0)
+                )
+            )
+            .map { $0.flyers.map(\.fragments.flyerFields) }
+            .sink { [weak self] completion in
+                self?.networkState?.handleCompletion(screen: .reads, completion)
+            } receiveValue: { [weak self] flyerFields in
+                let newFlyers = [Flyer](flyerFields.sorted { $0.endDate > $1.endDate })
+
+                if newFlyers.count < Int(Constants.pageSize) {
+                    self?.hasMorePages = false
+                }
+
+                withAnimation(.linear(duration: Constants.animationDuration)) {
+                    self?.flyers = (self?.flyers ?? []) + newFlyers
+                }
+            }
+            .store(in: &queryBag)
+        }
+
+    }
+
+}

--- a/Volume/View Models/OrganizationListViewModel.swift
+++ b/Volume/View Models/OrganizationListViewModel.swift
@@ -58,7 +58,9 @@ extension OrganizationList {
                 .sink { [weak self] completion in
                     self?.networkState?.handleCompletion(screen: .flyers, completion)
                 } receiveValue: { [weak self] organizationFields in
-                    let orgs = [Organization](organizationFields)
+                    var orgs = [Organization](organizationFields)
+                    orgs = orgs.sorted { $0.name < $1.name }
+
                     self?.followedOrgs = orgs.filter { userData.isOrganizationFollowed($0) }
                     self?.unfollowedOrgs = orgs.filter { !userData.isOrganizationFollowed($0) }
                 }

--- a/Volume/View Models/OrganizationListViewModel.swift
+++ b/Volume/View Models/OrganizationListViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  OrganizationListViewModel.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/16/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Combine
+import SwiftUI
+
+extension OrganizationList {
+
+    @MainActor
+    class ViewModel: ObservableObject {
+
+        // MARK: - Properties
+
+        @Published var followedOrgs: [Organization]?
+        @Published var unfollowedOrgs: [Organization]?
+
+        private var networkState: NetworkState?
+        private var queryBag = Set<AnyCancellable>()
+        private var userData: UserData?
+
+        // MARK: - Property Helpers
+
+        func setupEnvironmentVariables(networkState: NetworkState, userData: UserData) {
+            self.networkState = networkState
+            self.userData = userData
+        }
+
+        var hasFollowedOrganizations: Bool {
+            guard let userData else { return false }
+
+            return !userData.followedOrganizationSlugs.isEmpty
+        }
+
+        // MARK: - Network Requests
+
+        func refreshContent() {
+            Network.shared.clearCache()
+            queryBag.removeAll()
+
+            followedOrgs = nil
+            unfollowedOrgs = nil
+
+            Task {
+                await fetchAllOrganizations()
+            }
+        }
+
+        func fetchAllOrganizations() async {
+            guard let userData else { return }
+
+            Network.shared.publisher(for: GetAllOrganizationsQuery())
+                .map { $0.organizations.map(\.fragments.organizationFields) }
+                .sink { [weak self] completion in
+                    self?.networkState?.handleCompletion(screen: .flyers, completion)
+                } receiveValue: { [weak self] organizationFields in
+                    let orgs = [Organization](organizationFields)
+                    self?.followedOrgs = orgs.filter { userData.isOrganizationFollowed($0) }
+                    self?.unfollowedOrgs = orgs.filter { !userData.isOrganizationFollowed($0) }
+                }
+                .store(in: &queryBag)
+        }
+
+    }
+
+}

--- a/Volume/View Models/PublicationContentViewModel.swift
+++ b/Volume/View Models/PublicationContentViewModel.swift
@@ -86,7 +86,7 @@ extension PublicationContentView {
             )
             .map { $0.articles.map(\.fragments.articleFields) }
             .sink { [weak self] completion in
-                self?.networkState?.handleCompletion(screen: .publications, completion)
+                self?.networkState?.handleCompletion(screen: .reads, completion)
             } receiveValue: { [weak self] articleFields in
                 let newArticles = [Article](articleFields.sorted { $0.date > $1.date })
 

--- a/Volume/Views/Flyers/FlyerCellUpcoming.swift
+++ b/Volume/Views/Flyers/FlyerCellUpcoming.swift
@@ -24,7 +24,7 @@ struct FlyerCellUpcoming: View {
 
     private struct Constants {
         static let buttonSize: CGSize = CGSize(width: 18, height: 18)
-        static let cellWidth: CGFloat = 352
+        static let cellWidth: CGFloat = UIScreen.main.bounds.width - 32
         static let cellHeight: CGFloat = 92
         static let dateFont: Font = .helveticaRegular(size: 12)
         static let imageHeight: CGFloat = 92

--- a/Volume/Views/MainView and Tabs/FlyersView.swift
+++ b/Volume/Views/MainView and Tabs/FlyersView.swift
@@ -12,6 +12,8 @@ struct FlyersView: View {
 
     // MARK: - Properties
 
+    @Binding var showHamburger: Bool
+
     @EnvironmentObject private var networkState: NetworkState
     @EnvironmentObject private var userData: UserData
     @StateObject private var viewModel = ViewModel()
@@ -55,7 +57,22 @@ struct FlyersView: View {
     private var listContent: some View {
         List {
             Group {
-                searchBar
+                HStack {
+                    searchBar
+
+                    Spacer()
+
+                    HamburgerMenuView()
+                        .onTapGesture {
+                            Haptics.shared.play(.light)
+                            withAnimation(.spring()) {
+                                showHamburger.toggle()
+                            }
+                        }
+
+                    Spacer()
+                    Spacer()
+                }
                 if let flyers = viewModel.dailyFlyers {
                     !flyers.isEmpty ? todaySection : nil
                 }

--- a/Volume/Views/MainView and Tabs/ReadsView.swift
+++ b/Volume/Views/MainView and Tabs/ReadsView.swift
@@ -12,7 +12,7 @@ struct ReadsView: View {
 
     // MARK: - Properties
 
-    @Binding var showPublication: Bool
+    @Binding var showHamburger: Bool
     @StateObject private var viewModel = ViewModel()
 
     let navBarAppearance: UINavigationBarAppearance = {
@@ -62,7 +62,7 @@ struct ReadsView: View {
                         .onTapGesture {
                             Haptics.shared.play(.light)
                             withAnimation(.spring()) {
-                                showPublication.toggle()
+                                showHamburger.toggle()
                             }
                         }
 

--- a/Volume/Views/Organizations/FollowingOrganizationRow.swift
+++ b/Volume/Views/Organizations/FollowingOrganizationRow.swift
@@ -1,21 +1,25 @@
 //
-//  FollowingPublicationRow.swift
+//  FollowingOrganizationRow.swift
 //  Volume
 //
-//  Created by Cameron Russell on 10/29/20.
-//  Copyright © 2020 Cornell AppDev. All rights reserved.
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
 //
 
 import SDWebImageSwiftUI
 import SwiftUI
 
-/// `FollowingPublicationRow` displays the images and name of a publication a user is currently following
-struct FollowingPublicationRow: View {
-    let publication: Publication
+struct FollowingOrganizationRow: View {
+
+    // MARK: - Properties
+
+    let organization: Organization
+
+    // MARK: - UI
 
     var body: some View {
         VStack(spacing: 5) {
-            if let url = publication.profileImageUrl {
+            if let url = organization.profileImageUrl {
                 WebImage(url: url)
                     .resizable()
                     .grayBackground()
@@ -25,24 +29,32 @@ struct FollowingPublicationRow: View {
                     .transition(.fade(duration: 0.5))
                     .padding(.top, 4)
             } else {
-                Circle()
-                    .foregroundColor(.gray)
-                    .frame(width: 75, height: 75)
-                    .shadow(color: Color(white: 0, opacity: 0.1), radius: 5)
-                    .padding(.top, 4)
+                noProfileImageView
             }
-            Text(publication.name)
+
+            Text(organization.name)
                 .font(.newYorkMedium(size: 12))
                 .foregroundColor(.black)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
+
             Spacer()
         }
         .frame(width: 90, height: 135)
     }
+
+    private var noProfileImageView: some View {
+        Circle()
+            .foregroundColor(.gray)
+            .frame(width: 75, height: 75)
+            .shadow(color: Color(white: 0, opacity: 0.1), radius: 5)
+            .padding(.top, 4)
+    }
+
 }
 
-extension FollowingPublicationRow {
+extension FollowingOrganizationRow {
+
     struct Skeleton: View {
         var body: some View {
             VStack(spacing: 5) {
@@ -51,26 +63,15 @@ extension FollowingPublicationRow {
                     .shadow(color: Color(white: 0, opacity: 0.1), radius: 5)
                     .frame(width: 75, height: 75)
                     .padding(.top, 4)
+
                 SkeletonView()
                     .frame(width: 65, height: 14)
+
                 Spacer()
             }
             .frame(width: 90, height: 135)
             .shimmer(.smallShimmer())
         }
     }
-}
 
-//struct FollowingPublicationRow_Previews: PreviewProvider {
-//    static var previews: some View {
-//        FollowingPublicationRow(
-//            publication: Publication(
-//                description: "CU",
-//                name: "CUNooz",
-//                id: "sdfsdf",
-//                imageURL: nil,
-//                recent: "Sandpaper Tastes Like What?!"
-//            )
-//        )
-//    }
-//}
+}

--- a/Volume/Views/Organizations/MoreOrganizationRow.swift
+++ b/Volume/Views/Organizations/MoreOrganizationRow.swift
@@ -1,0 +1,143 @@
+//
+//  MoreOrganizationRow.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import AppDevAnalytics
+import SDWebImageSwiftUI
+import SwiftUI
+
+struct MoreOrganizationRow: View {
+
+    // MARK: - Properties
+
+    @EnvironmentObject private var userData: UserData
+    @State private var followRequestInProgress = false
+
+    let organization: Organization
+    let navigationSource: NavigationSource
+
+    // MARK: - UI
+
+    var body: some View {
+        HStack(alignment: .top) {
+            orgImageView
+            orgDetailView
+
+            Spacer()
+
+            followButton
+        }
+    }
+
+    @ViewBuilder
+    private var orgImageView: some View {
+        if let imageUrl = organization.profileImageUrl {
+            WebImage(url: imageUrl)
+                .grayBackground()
+                .resizable()
+                .clipShape(Circle())
+                .frame(width: 60, height: 60)
+        } else {
+            noProfileImageView
+        }
+    }
+
+    private var orgDetailView: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(organization.name)
+                .font(.newYorkMedium(size: 18))
+                .foregroundColor(.black)
+
+            Text(organization.bio ?? "")
+                .font(.helveticaRegular(size: 12))
+                .foregroundColor(Color(white: 151 / 255))
+                .truncationMode(.tail)
+                .lineSpacing(4)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .multilineTextAlignment(.leading)
+    }
+
+    private var followButton: some View {
+        Button {
+            Haptics.shared.play(.light)
+            
+            withAnimation {
+                followRequestInProgress = true
+                userData.toggleOrganizationFollowed(organization, $followRequestInProgress)
+
+                AppDevAnalytics.log(
+                    userData.isOrganizationFollowed(organization)
+                    ? VolumeEvent.followOrganization.toEvent(
+                        .organization,
+                        value: organization.slug,
+                        navigationSource: navigationSource
+                    ) : VolumeEvent.unfollowOrganization.toEvent(
+                        .organization,
+                        value: organization.slug,
+                        navigationSource: navigationSource
+                    )
+                )
+            }
+        } label: {
+            Image(userData.isOrganizationFollowed(organization) ? "followed" : "follow")
+        }
+        .disabled(followRequestInProgress)
+    }
+
+    private var noProfileImageView: some View {
+        Circle()
+            .fill(Color.gray)
+            .frame(width: 60, height: 60)
+    }
+
+}
+
+extension MoreOrganizationRow {
+
+    struct Skeleton: View {
+        var body: some View {
+            HStack(alignment: .top) {
+                SkeletonView()
+                    .clipShape(Circle())
+                    .frame(width: 60, height: 60)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    SkeletonView()
+                        .frame(width: 80, height: 23)
+                        .padding(.bottom, 5)
+
+                    SkeletonView()
+                        .frame(height: 15)
+                        .padding(.bottom, 4)
+                    SkeletonView()
+                        .frame(height: 15)
+                        .padding(.bottom, 5)
+
+                    HStack {
+                        Text("|")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundColor(Color(white: 225 / 255))
+                        SkeletonView()
+                            .frame(height: 14)
+                    }
+                    .padding(.top, 2)
+                }
+
+                Spacer()
+
+                SkeletonView()
+                    .frame(width: 24, height: 24)
+                    .cornerRadius(8)
+            }
+            .padding([.leading, .trailing])
+            .shimmer(.smallShimmer())
+        }
+    }
+
+}

--- a/Volume/Views/Organizations/MoreOrganizationRow.swift
+++ b/Volume/Views/Organizations/MoreOrganizationRow.swift
@@ -66,7 +66,7 @@ struct MoreOrganizationRow: View {
     private var followButton: some View {
         Button {
             Haptics.shared.play(.light)
-            
+
             withAnimation {
                 followRequestInProgress = true
                 userData.toggleOrganizationFollowed(organization, $followRequestInProgress)

--- a/Volume/Views/Organizations/MoreOrganizationRow.swift
+++ b/Volume/Views/Organizations/MoreOrganizationRow.swift
@@ -73,11 +73,11 @@ struct MoreOrganizationRow: View {
 
                 AppDevAnalytics.log(
                     userData.isOrganizationFollowed(organization)
-                    ? VolumeEvent.followOrganization.toEvent(
+                    ? VolumeEvent.unfollowOrganization.toEvent(
                         .organization,
                         value: organization.slug,
                         navigationSource: navigationSource
-                    ) : VolumeEvent.unfollowOrganization.toEvent(
+                    ) : VolumeEvent.followOrganization.toEvent(
                         .organization,
                         value: organization.slug,
                         navigationSource: navigationSource

--- a/Volume/Views/Organizations/OrganizationContentView.swift
+++ b/Volume/Views/Organizations/OrganizationContentView.swift
@@ -1,0 +1,107 @@
+//
+//  OrganizationContentView.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+
+struct OrganizationContentView: View {
+
+    // MARK: - Properties
+
+    let navigationSource: NavigationSource
+    let organization: Organization
+
+    @Namespace private var namespace
+    @EnvironmentObject private var networkState: NetworkState
+    @StateObject private var viewModel = ViewModel()
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let sidePadding: CGFloat = 16
+        static let spacing: CGFloat = 16
+    }
+
+    // MARK: - UI
+
+    var body: some View {
+        Group {
+            switch viewModel.flyers {
+            case .none:
+                loadingView
+            case .some(let flyers):
+                if flyers.count == 0 {
+                    emptyStateMessage
+                } else {
+                    flyerContent
+                }
+            }
+        }
+        .onAppear {
+            viewModel.setupEnvironmentVariables(networkState: networkState, organization: organization)
+            Task {
+                await viewModel.fetchFlyersPage()
+            }
+        }
+    }
+
+    private var loadingView: some View {
+        VStack(alignment: .center) {
+            Spacer()
+                .frame(height: 180)
+
+            ProgressView()
+        }
+    }
+
+    private var flyerContent: some View {
+        LazyVStack(alignment: .leading, spacing: Constants.spacing) {
+            Header("Flyers")
+
+            switch viewModel.flyers {
+            case .none:
+                ForEach(0..<5) { _ in
+                    FlyerCellUpcoming.Skeleton()
+                }
+            case .some(let flyers):
+                ForEach(flyers) { flyer in
+                    FlyerCellUpcoming(
+                        flyer: flyer,
+                        navigationSource: navigationSource,
+                        urlImageModel: URLImageModel(urlString: flyer.imageUrl?.absoluteString ?? ""),
+                        viewModel: FlyersView.ViewModel()
+                    )
+                    .onAppear {
+                        viewModel.fetchPageIfLast(flyer: flyer)
+                    }
+                }
+
+                if viewModel.hasMorePages {
+                    FlyerCellUpcoming.Skeleton()
+                }
+            }
+        }
+        .padding(.horizontal, Constants.sidePadding)
+    }
+
+    // MARK: - Supporting Views
+
+    private var emptyStateMessage: some View {
+        VStack {
+            Header("Flyers")
+
+            VolumeMessage(
+                message: .noFlyersOrgDetail,
+                largeFont: false,
+                fullWidth: false
+            )
+            .padding(.top, 128)
+        }
+        .padding(.horizontal, Constants.sidePadding)
+    }
+
+}

--- a/Volume/Views/Organizations/OrganizationDetail.swift
+++ b/Volume/Views/Organizations/OrganizationDetail.swift
@@ -1,0 +1,146 @@
+//
+//  OrganizationDetail.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SDWebImageSwiftUI
+import SwiftUI
+
+struct OrganizationDetail: View {
+
+    // MARK: - Properties
+
+    let navigationSource: NavigationSource
+    let organization: Organization
+
+    @GestureState private var dragOffset = CGSize.zero
+    @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let backButtonLeadingPadding: CGFloat = 20
+        static let backButtonTopPadding: CGFloat = 55
+        static let coverImageHeight: CGFloat = 140
+        static let coverImageOverlayHeight: CGFloat = 156
+        static let dividerWidth: CGFloat = 100
+        static let dragGestureMaxX: CGFloat = 100
+        static let dragGestureMinX: CGFloat = 20
+        static let horizontalPadding: CGFloat = 18
+        static let profileImageDimension: CGFloat = 60
+        static let profileImageStrokeWidth: CGFloat = 3
+        static let shadowRadius: CGFloat = 4
+    }
+
+    // MARK: - UI
+
+    var body: some View {
+        GeometryReader { _ in
+            ScrollView {
+                coverImageHeader
+                contentSection
+            }
+            .navigationBarHidden(true)
+            .edgesIgnoringSafeArea(.top)
+            .background(Color.white)
+            .gesture(
+                DragGesture().updating($dragOffset) { value, _, _ in
+                    if value.startLocation.x < Constants.dragGestureMinX,
+                       value.translation.width > Constants.dragGestureMaxX {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            )
+        }
+    }
+
+    private var coverImageHeader: some View {
+        VStack(alignment: .center) {
+            ZStack {
+                coverImage
+                coverImageOverlay
+            }
+            .frame(height: Constants.coverImageOverlayHeight)
+
+            orgDescription
+            divider
+        }
+    }
+
+    private var coverImage: some View {
+        GeometryReader { geometry in
+            let scrollOffset = geometry.frame(in: .global).minY
+            let headerOffset = scrollOffset > 0 ? -scrollOffset : 0
+            let headerHeight = geometry.size.height + max(scrollOffset, 0)
+
+            WebImage(url: organization.backgroundImageUrl)
+                .resizable()
+                .grayBackground()
+                .scaledToFill()
+                .frame(width: geometry.size.width, height: headerHeight)
+                .clipped()
+                .offset(y: headerOffset)
+        }
+        .frame(height: Constants.coverImageHeight)
+    }
+
+    private var coverImageOverlay: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Button {
+                    self.presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image.volume.backArrow
+                        .foregroundColor(Color.white)
+                        .padding(.top, Constants.backButtonTopPadding)
+                        .padding(.leading, Constants.backButtonLeadingPadding)
+                        .shadow(color: Color.black, radius: Constants.shadowRadius)
+                }
+
+                Spacer()
+
+                WebImage(url: organization.profileImageUrl)
+                    .grayBackground()
+                    .resizable()
+                    .clipShape(Circle())
+                    .frame(width: Constants.profileImageDimension, height: Constants.profileImageDimension)
+                    .overlay(
+                        Circle()
+                            .stroke(Color.white, lineWidth: Constants.profileImageStrokeWidth)
+                    )
+                    .shadow(color: Color.volume.shadowBlack, radius: Constants.shadowRadius)
+                    .padding(.leading, Constants.horizontalPadding)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var orgDescription: some View {
+        OrganizationDetailHeader(
+            navigationSource: navigationSource,
+            organization: organization
+        )
+        .padding(.bottom)
+    }
+
+    private var contentSection: some View {
+        OrganizationContentView(
+            navigationSource: navigationSource,
+            organization: organization
+        )
+        .padding(.top, 16)
+    }
+
+    // MARK: - Supporting Views
+
+    private var divider: some View {
+        Divider()
+            .background(Color.volume.veryLightGray)
+            .frame(width: Constants.dividerWidth)
+    }
+
+}

--- a/Volume/Views/Organizations/OrganizationDetailHeader.swift
+++ b/Volume/Views/Organizations/OrganizationDetailHeader.swift
@@ -82,12 +82,12 @@ struct OrganizationDetailHeader: View {
 
             AppDevAnalytics.log(
                 userData.isOrganizationFollowed(organization)
-                ? VolumeEvent.followOrganization.toEvent(
+                ? VolumeEvent.unfollowOrganization.toEvent(
                     .organization,
                     value: organization.slug,
                     navigationSource: navigationSource
                 )
-                : VolumeEvent.unfollowOrganization.toEvent(
+                : VolumeEvent.followOrganization.toEvent(
                     .organization,
                     value: organization.slug,
                     navigationSource: navigationSource

--- a/Volume/Views/Organizations/OrganizationDetailHeader.swift
+++ b/Volume/Views/Organizations/OrganizationDetailHeader.swift
@@ -1,0 +1,130 @@
+//
+//  OrganizationDetailHeader.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/17/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import AppDevAnalytics
+import SwiftUI
+
+struct OrganizationDetailHeader: View {
+
+    // MARK: - Properties
+
+    let navigationSource: NavigationSource
+    let organization: Organization
+
+    @State private var followRequestInProgress = false
+    @EnvironmentObject private var userData: UserData
+
+    // MARK: - Computed Properties
+
+    /// Returns `true` if this user follows the organization. `false` otherwise.
+    private var isFollowed: Bool {
+        userData.isOrganizationFollowed(organization)
+    }
+
+    /// Returns `true` if the organization's website URL is Instagram. `false` otherwise.
+    private var isInstagram: Bool {
+        guard let url = organization.websiteUrl else { return false }
+
+        return url.absoluteString.contains("instagram")
+    }
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let iconGray: Color = Color(white: 196 / 255)
+        static let sidePadding: CGFloat = 16
+        static let spacing: CGFloat = 16
+    }
+
+    // MARK: - UI
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.spacing) {
+            HStack(alignment: .center) {
+                Text(organization.name)
+                    .font(.newYorkMedium(size: 18))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                followButton
+            }
+
+            // TODO: Wait till backend creates a metric for num flyers
+            Text("\(3) events  •  \(3) upcoming events")
+                .font(.helveticaRegular(size: 12))
+                .foregroundColor(Color(white: 151 / 255))
+
+            if let bio = organization.bio, !bio.isEmpty {
+                Text(bio)
+                    .font(.helveticaRegular(size: 14))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let websiteUrl = organization.websiteUrl {
+                externalLink(websiteUrl)
+            }
+        }
+        .padding(.horizontal, Constants.sidePadding)
+        .padding(.top, 12)
+    }
+
+    private var followButton: some View {
+        Button {
+            Haptics.shared.play(.light)
+            followRequestInProgress = true
+            userData.toggleOrganizationFollowed(organization, $followRequestInProgress)
+
+            AppDevAnalytics.log(
+                userData.isOrganizationFollowed(organization)
+                ? VolumeEvent.followOrganization.toEvent(
+                    .organization,
+                    value: organization.slug,
+                    navigationSource: navigationSource
+                )
+                : VolumeEvent.unfollowOrganization.toEvent(
+                    .organization,
+                    value: organization.slug,
+                    navigationSource: navigationSource
+                )
+            )
+        } label: {
+            Text(isFollowed ? "Following" : "+  Follow")
+                .font(.helveticaNeueMedium(size: 12))
+                .padding(EdgeInsets(top: 8, leading: 18, bottom: 8, trailing: 18))
+        }
+        .disabled(followRequestInProgress)
+        .foregroundColor(isFollowed ? Color.volume.buttonGray: Color.volume.orange)
+        .background(
+            isFollowed
+            ? AnyView(RoundedRectangle(cornerRadius: 10).fill(Color.volume.orange))
+            : AnyView(RoundedRectangle(cornerRadius: 10).stroke(Color.volume.orange, lineWidth: 1.5))
+        )
+    }
+
+    private func externalLink(_ websiteURL: URL) -> some View {
+        HStack {
+            if isInstagram {
+                Image.volume.insta
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .foregroundColor(Constants.iconGray)
+
+                MediaText(title: "Instagram", url: websiteURL)
+            } else {
+                Image.volume.link
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .foregroundColor(Constants.iconGray)
+
+                MediaText(title: "Website", url: websiteURL)
+            }
+        }
+    }
+
+}

--- a/Volume/Views/Organizations/OrganizationDetailHeader.swift
+++ b/Volume/Views/Organizations/OrganizationDetailHeader.swift
@@ -55,8 +55,7 @@ struct OrganizationDetailHeader: View {
                 followButton
             }
 
-            // TODO: Wait till backend creates a metric for num flyers
-            Text("\(3) events  •  \(3) upcoming events")
+            Text("\(organization.numFlyers) events")
                 .font(.helveticaRegular(size: 12))
                 .foregroundColor(Color(white: 151 / 255))
 

--- a/Volume/Views/Organizations/OrganizationList.swift
+++ b/Volume/Views/Organizations/OrganizationList.swift
@@ -1,0 +1,144 @@
+//
+//  OrganizationList.swift
+//  Volume
+//
+//  Created by Vin Bui on 11/16/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import SwiftUI
+
+struct OrganizationList: View {
+
+    // MARK: - Properties
+
+    @EnvironmentObject private var networkState: NetworkState
+    @EnvironmentObject private var userData: UserData
+    @StateObject private var viewModel = ViewModel()
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let colSpacing: CGFloat = 12
+        static let rowSpacing: CGFloat = 16
+        static let sidePadding: CGFloat = 16
+    }
+
+    // MARK: - UI
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack {
+                followedOrgsSection
+
+                EmptyView()
+                    .frame(height: 16)
+
+                moreOrgsSection
+            }
+        }
+        .padding(.top)
+        .background(Color.white)
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+            viewModel.refreshContent()
+        }
+        .disabled(viewModel.followedOrgs == nil && viewModel.unfollowedOrgs == nil)
+        .onAppear {
+            viewModel.setupEnvironmentVariables(networkState: networkState, userData: userData)
+
+            Task {
+                await viewModel.fetchAllOrganizations()
+            }
+        }
+    }
+
+    private var followedOrgsSection: some View {
+        Section {
+            followedOrgsScrollView
+        } header: {
+            Header("Following")
+                .padding([.leading, .top, .trailing])
+                .padding(.bottom, 6)
+        }
+    }
+
+    private var followedOrgsScrollView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: Constants.colSpacing) {
+                switch viewModel.followedOrgs {
+                case .none:
+                    ForEach(0..<4, id: \.self) { _ in
+                        FollowingOrganizationRow.Skeleton()
+                    }
+                case .some(let orgs):
+                    if orgs.isEmpty {
+                        noFollowedOrgsMessage
+                    } else {
+                        ForEach(orgs) { org in
+                            NavigationLink {
+                                OrganizationDetail(
+                                    navigationSource: .flyersTab,
+                                    organization: org
+                                )
+                            } label: {
+                                FollowingOrganizationRow(organization: org)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, Constants.sidePadding)
+        }
+        .disabled(!viewModel.hasFollowedOrganizations)
+    }
+
+    private var moreOrgsSection: some View {
+        Section {
+            LazyVStack {
+                switch viewModel.unfollowedOrgs {
+                case .none:
+                    ForEach(0..<5) { _ in
+                        MorePublicationRow.Skeleton()
+                            .padding(.bottom, 15)
+                    }
+                case .some(let orgs):
+                    ForEach(orgs) { org in
+                        NavigationLink {
+                            OrganizationDetail(
+                                navigationSource: .flyersTab,
+                                organization: org
+                            )
+                        } label: {
+                            MoreOrganizationRow(organization: org, navigationSource: .flyersTab)
+                                .padding(.bottom, Constants.rowSpacing)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, Constants.sidePadding)
+        } header: {
+            Header("More organizations")
+                .padding([.leading, .top, .trailing])
+                .padding(.bottom, 6)
+        }
+    }
+
+    // MARK: - Supporting Views
+
+    private var noFollowedOrgsMessage: some View {
+        VolumeMessage(
+            image: Image.volume.flyer,
+            message: .noFollowingOrganizations,
+            largeFont: false,
+            fullWidth: true
+        )
+    }
+
+}
+
+// MARK: - Uncomment below if needed
+
+//#Preview {
+//    OrganizationList()
+//}

--- a/Volume/Views/Organizations/OrganizationList.swift
+++ b/Volume/Views/Organizations/OrganizationList.swift
@@ -127,12 +127,18 @@ struct OrganizationList: View {
     // MARK: - Supporting Views
 
     private var noFollowedOrgsMessage: some View {
-        VolumeMessage(
-            image: Image.volume.flyer,
-            message: .noFollowingOrganizations,
-            largeFont: false,
-            fullWidth: true
-        )
+        HStack {
+            Spacer()
+
+            VolumeMessage(
+                image: Image.volume.flyer,
+                message: .noFollowingOrganizations,
+                largeFont: false,
+                fullWidth: true
+            )
+
+            Spacer()
+        }
     }
 
 }

--- a/Volume/Views/Publications/MorePublicationRow.swift
+++ b/Volume/Views/Publications/MorePublicationRow.swift
@@ -1,5 +1,5 @@
 //
-//  PublicationRow.swift
+//  MorePublicationRow.swift
 //  Volume
 //
 //  Created by Cameron Russell on 10/29/20.
@@ -12,6 +12,7 @@ import SwiftUI
 
 /// `MorePublicationRow` displays the basis information about a publications the user is not currently following
 struct MorePublicationRow: View {
+
     @EnvironmentObject private var userData: UserData
     @State private var followRequestInProgress = false
 
@@ -88,6 +89,7 @@ struct MorePublicationRow: View {
 }
 
 extension MorePublicationRow {
+
     struct Skeleton: View {
         var body: some View {
             HStack(alignment: .top) {
@@ -122,10 +124,12 @@ extension MorePublicationRow {
                 SkeletonView()
                     .frame(width: 24, height: 24)
                     .cornerRadius(8)
-            }.padding([.leading, .trailing])
-                .shimmer(.smallShimmer())
+            }
+            .padding([.leading, .trailing])
+            .shimmer(.smallShimmer())
         }
     }
+
 }
 
 //struct MorePublicationRow_Previews: PreviewProvider {

--- a/Volume/Views/Publications/MorePublicationRow.swift
+++ b/Volume/Views/Publications/MorePublicationRow.swift
@@ -68,11 +68,11 @@ struct MorePublicationRow: View {
                     userData.togglePublicationFollowed(publication, $followRequestInProgress)
                     AppDevAnalytics.log(
                         userData.isPublicationFollowed(publication)
-                        ? VolumeEvent.followPublication.toEvent(
+                        ? VolumeEvent.unfollowPublication.toEvent(
                             .publication,
                             value: publication.slug,
                             navigationSource: navigationSource
-                        ) : VolumeEvent.unfollowPublication.toEvent(
+                        ) : VolumeEvent.followPublication.toEvent(
                             .publication,
                             value: publication.slug,
                             navigationSource: navigationSource

--- a/Volume/Views/Publications/PublicationDetailHeader.swift
+++ b/Volume/Views/Publications/PublicationDetailHeader.swift
@@ -101,16 +101,3 @@ struct PublicationDetailHeader: View {
         .padding([.top, .horizontal])
     }
 }
-
-struct MediaText: View {
-    let title: String
-    let url: URL
-
-    var body: some View {
-        Link(title, destination: url)
-            .font(.helveticaRegular(size: 12))
-            .foregroundColor(.volume.orange)
-            .padding(.trailing, 10)
-            .lineLimit(1)
-    }
-}

--- a/Volume/Views/Publications/PublicationDetailHeader.swift
+++ b/Volume/Views/Publications/PublicationDetailHeader.swift
@@ -64,12 +64,12 @@ struct PublicationDetailHeader: View {
                     userData.togglePublicationFollowed(publication, $followRequestInProgress)
                     AppDevAnalytics.log(
                         userData.isPublicationFollowed(publication)
-                        ? VolumeEvent.followPublication.toEvent(
+                        ? VolumeEvent.unfollowPublication.toEvent(
                             .publication,
                             value: publication.slug,
                             navigationSource: navigationSource
                         )
-                        : VolumeEvent.unfollowPublication.toEvent(
+                        : VolumeEvent.followPublication.toEvent(
                             .publication,
                             value: publication.slug,
                             navigationSource: navigationSource

--- a/Volume/Views/Weekly Debrief/WeeklyDebriefView.swift
+++ b/Volume/Views/Weekly Debrief/WeeklyDebriefView.swift
@@ -66,12 +66,6 @@ struct WeeklyDebriefView: View {
                     number: weeklyDebrief.numShoutouts,
                     rightText: "shout-outs"
                 )
-                StatisticView(
-                    image: .volume.bookmark,
-                    leftText: "bookmarked",
-                    number: weeklyDebrief.numBookmarkedArticles,
-                    rightText: "articles"
-                )
 
                 HStack {
                     Text("Keep up the volume! 📣")

--- a/VolumeWidget/FlyerWidget/FlyerWidgetIntent.swift
+++ b/VolumeWidget/FlyerWidget/FlyerWidgetIntent.swift
@@ -87,7 +87,7 @@ struct WidgetOrganizationQuery: EntityStringQuery {
     // MARK: - Network Requests
 
     private func fetchOrganizationNames(completion: @escaping ([Organization]) -> Void) {
-        Network.shared.publisher(for: GetAllOrganizationNamesQuery())
+        Network.shared.publisher(for: GetAllOrganizationsQuery())
             .map { $0.organizations.map(\.fragments.organizationFields) }
             .sink { completion in
                 if case let .failure(error) = completion {

--- a/VolumeWidget/FlyerWidget/FlyerWidgetProvider.swift
+++ b/VolumeWidget/FlyerWidget/FlyerWidgetProvider.swift
@@ -76,6 +76,7 @@ extension FlyerWidgetProvider {
                 "bio": "",
                 "categorySlug": "cultural",
                 "name": "Cornell Filipino Association",
+                "numFlyers": 3,
                 "profileImageURL": "https://raw.githubusercontent.com/cuappdev/assets/master/volume/cfa/profile.png",
                 "slug": "cfa",
                 "shoutouts": 0,

--- a/VolumeWidget/WidgetViewModel.swift
+++ b/VolumeWidget/WidgetViewModel.swift
@@ -40,7 +40,7 @@ final class WidgetViewModel {
     }
 
     func fetchOrganizationNames(completion: @escaping ([Organization]) -> Void) {
-        Network.shared.publisher(for: GetAllOrganizationNamesQuery())
+        Network.shared.publisher(for: GetAllOrganizationsQuery())
             .map { $0.organizations.map(\.fragments.organizationFields) }
             .sink { completion in
                 if case let .failure(error) = completion {


### PR DESCRIPTION
## Overview

Created the organization detail page as well as the organizations list view.

## Changes Made

### Organization List View

- Created a scrollable list containing the organizations we are partnered with.
    - Followed organizations are displayed at the top with horizontal scrolling and will not show in the “More organizations” section.
    - Sorted alphabetically.
- There is gray placeholder image for the profile image if it is missing.
    - The bio will also not show if it is empty.
- Tapping on the cell will push the organization detail view.
- The state of the follow button will depend on whether or not the current user follows that organization.
    - Tapping on this button will toggle follow and will trigger our Analytics. Note that you must refresh in order to see it updated.
- If there are no followed organizations, an empty message is shown.

### Organization Detail View

- A gray placeholder image is used for both the profile and background image.
    - The background image header is sticky and will stretch on scroll.
- If the organization’s website URL is an Instagram URL, an Instagram icon and text is used for the external link. Otherwise, a link icon and “Website” text is used.
- If the user is currently following the organization, the state of the Follow button will change.
    - This will allow the user to toggle follow in which the organization list view gets updated immediately.
    - This will also trigger our Analytics.
- There is a `// TODO` comment indicating that we must wait for backend to include a metric for number of events. Once that is done, then we can implement the text for it.
- If the organization’s bio is empty, we do not display it and the content below it gets shifted up.
- This view displays only a single section for Flyers (no separation between upcoming and past).
    - This uses pagination and infinite scrolling to prevent loading too many events at once. The page limit is 10 events.
- If there are no flyers, an empty message is shown.

## Test Coverage

- I tested to make sure that there was no interference between the Flyers and the Reads page with the hamburger icon as both of these have a binding access to properties in `MainView`.
- Checked database as well as the GraphQL playground to make sure that both the local storage and backend are updated.
- Pagination for the organization detail view has been tested to make sure that the flyers are loaded in smoothly and efficiently.

## Next Steps

- There is a `// TODO` comment indicating that we must wait for backend to include a metric for number of events. Once that is done, then we can implement the text for it.
- Once backend is done with bookmarking, we will need to send a backend call for bookmarks in order for this information to be stored in the database.
- Add pagination to the Organization List if we have too many organizations.

## Screenshots

https://github.com/cuappdev/volume-ios/assets/75594943/0e89679a-b4ac-40dd-bff9-9193a802e4c5