### PR TITLE
Update API declarations

### DIFF
--- a/Volume.xcodeproj/project.pbxproj
+++ b/Volume.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		2E6A7D7729DAC784002F5250 /* FlyerCellPast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6A7D7629DAC784002F5250 /* FlyerCellPast.swift */; };
 		2E6C36112AF5E355004A54BB /* OrgsAdminView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6C36102AF5E355004A54BB /* OrgsAdminView.swift */; };
 		2E6C36132AF5FF45004A54BB /* OrgsAdminViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6C36122AF5FF45004A54BB /* OrgsAdminViewModel.swift */; };
+		2E7043502BB75F10003AC1D6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2E70434F2BB75F10003AC1D6 /* PrivacyInfo.xcprivacy */; };
 		2E81EB6229F4DA5300A288C1 /* OnboardingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E81EB6129F4DA5300A288C1 /* OnboardingMainView.swift */; };
 		2E81EB6429F4EC8000A288C1 /* OnboardingWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E81EB6329F4EC8000A288C1 /* OnboardingWelcomeView.swift */; };
 		2E81EB6629F4F4A800A288C1 /* OnboardingFlyersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E81EB6529F4F4A800A288C1 /* OnboardingFlyersView.swift */; };
@@ -272,6 +273,7 @@
 		2E6A7D7629DAC784002F5250 /* FlyerCellPast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlyerCellPast.swift; sourceTree = "<group>"; };
 		2E6C36102AF5E355004A54BB /* OrgsAdminView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgsAdminView.swift; sourceTree = "<group>"; };
 		2E6C36122AF5FF45004A54BB /* OrgsAdminViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrgsAdminViewModel.swift; sourceTree = "<group>"; };
+		2E70434F2BB75F10003AC1D6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2E81EB6129F4DA5300A288C1 /* OnboardingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMainView.swift; sourceTree = "<group>"; };
 		2E81EB6329F4EC8000A288C1 /* OnboardingWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomeView.swift; sourceTree = "<group>"; };
 		2E81EB6529F4F4A800A288C1 /* OnboardingFlyersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlyersView.swift; sourceTree = "<group>"; };
@@ -790,8 +792,9 @@
 		7ED7C335252D117A0078B1BD /* Volume */ = {
 			isa = PBXGroup;
 			children = (
-				2E38E14E29E5CE4C006323E5 /* LaunchScreen.storyboard */,
 				7ED7C33C252D117B0078B1BD /* Assets.xcassets */,
+				2E38E14E29E5CE4C006323E5 /* LaunchScreen.storyboard */,
+				2E70434F2BB75F10003AC1D6 /* PrivacyInfo.xcprivacy */,
 				995C99FE25E576E600F6FBA5 /* Analytics */,
 				2E38E14B29E5CC2A006323E5 /* Lottie */,
 				7E51586325589D3F003A0F4A /* Models */,
@@ -938,6 +941,7 @@
 				922FE30D29342F9200E14911 /* schema.json in Resources */,
 				2EF894BA2A1F087F001DD2A1 /* FlyerMutations.graphql in Resources */,
 				7ED7C340252D117B0078B1BD /* Preview Assets.xcassets in Resources */,
+				2E7043502BB75F10003AC1D6 /* PrivacyInfo.xcprivacy in Resources */,
 				BC2C4C192909E74D0083C6AA /* MagazineQueries.graphql in Resources */,
 				2E4BAAA82ADB292D000ECCBD /* GoogleService-Info.plist in Resources */,
 				922FE3092931E67A00E14911 /* SearchQueries.graphql in Resources */,
@@ -1445,7 +1449,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 38;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
@@ -1458,7 +1462,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1477,7 +1481,7 @@
 				CODE_SIGN_ENTITLEMENTS = Volume/Volume.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 38;
 				DEVELOPMENT_ASSET_PATHS = "\"Volume/Preview Content\"";
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_PREVIEWS = YES;
@@ -1489,7 +1493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.4.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cornellappdev.volume-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Volume/PrivacyInfo.xcprivacy
+++ b/Volume/PrivacyInfo.xcprivacy
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string></string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string></string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>1C8F.1</string>
+                <string>CA92.1</string>
+            </array>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+                <string>3B52.1</string>
+                <string>DDA9.1</string>
+            </array>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+        </dict>
+    </array>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Overview

Added API declarations to the app required by Apple starting May 1, 2024.

## Changes Made

### File Timestamp APIs (NSPrivacyAccessedAPICategoryFileTimestamp)
- DDA9.1
  - Declare this reason to display file timestamps to the person using the device.
  - Information accessed for this reason, or any derived information, may not be sent off-device.
- C617.1
  - Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.
- 3B52.1
  - Declare this reason to access the timestamps, size, or other metadata of files or directories that the user specifically granted access to, such as using a document picker view controller.

### System Boot Time APIs (NSPrivacyAccessedAPICategorySystemBootTime)
- 35F9.1
  - Declare this reason to access the system boot time in order to measure the amount of time that has elapsed between events that occurred within the app or to perform calculations to enable timers.
  - Information accessed for this reason, or any derived information, may not be sent off-device. There is an exception for information about the amount of time that has elapsed between events that occurred within the app, which may be sent off-device.
- 8FFB.1
  - Declare this reason to access the system boot time to calculate absolute timestamps for events that occurred within your app, such as events related to the [UIKit](https://developer.apple.com/documentation/uikit) or [AVFAudio](https://developer.apple.com/documentation/avfaudio) frameworks.
  - Absolute timestamps for events that occurred within your app may be sent off-device. System boot time accessed for this reason, or any other information derived from system boot time, may not be sent off-device.
- 3D61.1
  - Declare this reason to include system boot time information in an optional bug report that the person using the device chooses to submit. The system boot time information must be prominently displayed to the person as part of the report.
  - Information accessed for this reason, or any derived information, may be sent off-device only after the user affirmatively chooses to submit the specific bug report including system boot time information, and only for the purpose of investigating or responding to the bug report.

### User Defaults APIs (NSPrivacyAccessedAPICategoryUserDefaults)
- CA92.1
  - Declare this reason to access user defaults to read and write information that is only accessible to the app itself.
  - This reason does not permit reading information that was written by other apps or the system, or writing information that can be accessed by other apps.
- 1C8F.1
  - Declare this reason to access user defaults to read and write information that is only accessible to the apps, app extensions, and App Clips that are members of the same App Group as the app itself.
  - This reason does not permit reading information that was written by apps, app extensions, or App Clips outside the same App Group or by the system. Your app is not responsible if the system provides information from the global domain because a key is not present in your requested domain while your app is attempting to read information that apps, app extensions, or App Clips in your app’s App Group write.
  - This reason also does not permit writing information that can be accessed by apps, app extensions, or App Clips outside the same App Group.

### Other Changes
- Set Privacy Tracking Enabled to YES.

## Next Steps
Upload a new binary to App Store Connect and wait for their review feedback.